### PR TITLE
expose getters for reconcilers to get created endpoint and transport

### DIFF
--- a/state_transfer/endpoint/route/route.go
+++ b/state_transfer/endpoint/route/route.go
@@ -229,9 +229,9 @@ func (r *RouteEndpoint) setFields(c client.Client) error {
 	return nil
 }
 
-// GetReadyEndpoint check if the required Route is created and healthy. It populates the fields
+// GetEndpointFromKubeObjects check if the required Route is created and healthy. It populates the fields
 // for the Endpoint needed for transfer and transport objects.
-func GetReadyEndpoint(c client.Client, obj types.NamespacedName) (endpoint.Endpoint, error) {
+func GetEndpointFromKubeObjects(c client.Client, obj types.NamespacedName) (endpoint.Endpoint, error) {
 	r := &RouteEndpoint{namespacedName: obj}
 
 	healthy, err := r.IsHealthy(c)

--- a/state_transfer/endpoint/route/route.go
+++ b/state_transfer/endpoint/route/route.go
@@ -190,3 +190,62 @@ func (r *RouteEndpoint) createRoute(c client.Client) error {
 func (r *RouteEndpoint) setPort(port int32) {
 	r.port = port
 }
+
+func (r *RouteEndpoint) getRoute(c client.Client) (*routev1.Route, error) {
+	route := &routev1.Route{}
+	err := c.Get(context.TODO(), types.NamespacedName{Name: r.NamespacedName().Name, Namespace: r.NamespacedName().Namespace}, route)
+	if err != nil {
+		return nil, err
+	}
+	return route, err
+}
+
+func (r *RouteEndpoint) setFields(c client.Client) error {
+	route, err := r.getRoute(c)
+	if err != nil {
+		return err
+	}
+
+	if route.Spec.Host == "" {
+		return fmt.Errorf("route %s has empty spec.host field", r.NamespacedName())
+	}
+	if route.Spec.Port == nil {
+		return fmt.Errorf("route %s has empty spec.port field", r.NamespacedName())
+	}
+
+	r.hostname = route.Spec.Host
+
+	r.port = route.Spec.Port.TargetPort.IntVal
+
+	switch route.Spec.TLS.Termination {
+	case routev1.TLSTerminationEdge:
+		r.endpointType = EndpointTypeInsecureEdge
+	case routev1.TLSTerminationPassthrough:
+		r.endpointType = EndpointTypePassthrough
+	default:
+		return fmt.Errorf("route %s has unsupported spec.spec.tls.termination value", r.NamespacedName())
+	}
+
+	return nil
+}
+
+// GetReadyEndpoint check if the required Route is created and healthy. It populates the fields
+// for the Endpoint needed for transfer and transport objects.
+func GetReadyEndpoint(c client.Client, obj types.NamespacedName) (endpoint.Endpoint, error) {
+	r := &RouteEndpoint{namespacedName: obj}
+
+	healthy, err := r.IsHealthy(c)
+	if err != nil {
+		return nil, err
+	}
+	if !healthy {
+		return nil, fmt.Errorf("route %s not healthy", obj)
+	}
+
+	err = r.setFields(c)
+	if err != nil {
+		return nil, err
+	}
+
+	return r, nil
+}

--- a/state_transfer/example_test.go
+++ b/state_transfer/example_test.go
@@ -124,12 +124,12 @@ func Example_getFromCreatedObjects() {
 	// set up the PVC on destination to receive the data
 	pvc := &corev1.PersistentVolumeClaim{}
 
-	e, err := route.GetReadyEndpoint(destClient, types.NamespacedName{Namespace: srcNamespace, Name: srcPVC})
+	e, err := route.GetEndpointFromKubeObjects(destClient, types.NamespacedName{Namespace: srcNamespace, Name: srcPVC})
 	if err != nil {
 		log.Fatal(err, "error getting route endpoint")
 	}
 
-	s, err := stunnel.GetTransport(srcClient, destClient, types.NamespacedName{Namespace: srcNamespace, Name: srcPVC})
+	s, err := stunnel.GetTransferFromKubeObjects(srcClient, destClient, types.NamespacedName{Namespace: srcNamespace, Name: srcPVC})
 	if err != nil {
 		log.Fatal(err, "error getting stunnel transfer")
 	}

--- a/state_transfer/transport/stunnel/stunnel.go
+++ b/state_transfer/transport/stunnel/stunnel.go
@@ -3,7 +3,6 @@ package stunnel
 import (
 	"bytes"
 	"fmt"
-
 	"github.com/konveyor/crane-lib/state_transfer/transport"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/types"
@@ -71,9 +70,9 @@ func (s *StunnelTransport) Direct() bool {
 	return s.direct
 }
 
-// GetTransport checks if the required configmaps and secretes are created for the transport
+// GetTransferFromKubeObjects checks if the required configmaps and secretes are created for the transport
 //. It populates the fields for the Transport needed for transfer object.
-func GetTransport(srcClient client.Client, destClient client.Client, obj types.NamespacedName) (transport.Transport, error) {
+func GetTransferFromKubeObjects(srcClient client.Client, destClient client.Client, obj types.NamespacedName) (transport.Transport, error) {
 	_, err := getClientConfig(srcClient, obj)
 	switch {
 	case errors.IsNotFound(err):

--- a/state_transfer/transport/stunnel/stunnel.go
+++ b/state_transfer/transport/stunnel/stunnel.go
@@ -2,10 +2,14 @@ package stunnel
 
 import (
 	"bytes"
+	"fmt"
 
 	"github.com/konveyor/crane-lib/state_transfer/transport"
+	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	v1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 )
 
 const (
@@ -20,10 +24,10 @@ type StunnelTransport struct {
 	key              *bytes.Buffer
 	ca               *bytes.Buffer
 	port             int32
-	serverContainers []v1.Container
-	serverVolumes    []v1.Volume
-	clientContainers []v1.Container
-	clientVolumes    []v1.Volume
+	serverContainers []corev1.Container
+	serverVolumes    []corev1.Volume
+	clientContainers []corev1.Container
+	clientVolumes    []corev1.Volume
 	direct           bool
 }
 
@@ -47,22 +51,84 @@ func (s *StunnelTransport) Port() int32 {
 	return s.port
 }
 
-func (s *StunnelTransport) ClientContainers() []v1.Container {
+func (s *StunnelTransport) ClientContainers() []corev1.Container {
 	return s.clientContainers
 }
 
-func (s *StunnelTransport) ServerContainers() []v1.Container {
+func (s *StunnelTransport) ServerContainers() []corev1.Container {
 	return s.serverContainers
 }
 
-func (s *StunnelTransport) ClientVolumes() []v1.Volume {
+func (s *StunnelTransport) ClientVolumes() []corev1.Volume {
 	return s.clientVolumes
 }
 
-func (s *StunnelTransport) ServerVolumes() []v1.Volume {
+func (s *StunnelTransport) ServerVolumes() []corev1.Volume {
 	return s.serverVolumes
 }
 
 func (s *StunnelTransport) Direct() bool {
 	return s.direct
+}
+
+// GetTransport checks if the required configmaps and secretes are created for the transport
+//. It populates the fields for the Transport needed for transfer object.
+func GetTransport(srcClient client.Client, destClient client.Client, obj types.NamespacedName) (transport.Transport, error) {
+	_, err := getClientConfig(srcClient, obj)
+	switch {
+	case errors.IsNotFound(err):
+		fmt.Printf("transport: %s Client Config is not created", obj)
+		return nil, err
+	case err != nil:
+		return nil, err
+	}
+
+	_, err = getServerConfig(destClient, obj)
+	switch {
+	case errors.IsNotFound(err):
+		fmt.Printf("transport: %s Server Config is not created", obj)
+		return nil, err
+	case err != nil:
+		return nil, err
+	}
+
+	clientSecretCreated, err := getClientSecret(srcClient, obj)
+	switch {
+	case errors.IsNotFound(err):
+		fmt.Printf("transport: %s Client secret is not created", obj)
+		return nil, err
+	case err != nil:
+		return nil, err
+	}
+
+	_, err = getServerSecret(destClient, obj)
+	switch {
+	case errors.IsNotFound(err):
+		fmt.Printf("transport: %s Server secret is not created", obj)
+		return nil, err
+	case err != nil:
+		return nil, err
+	}
+
+	s := &StunnelTransport{}
+
+	key, ok := clientSecretCreated.Data["tls.key"]
+	if !ok {
+		fmt.Printf("invalid secret for transport %s, tls.key key not found", obj)
+		return nil, fmt.Errorf("invalid secret for transport %s, tls.key key not found", obj)
+	}
+
+	crt, ok := clientSecretCreated.Data["tls.crt"]
+	if !ok {
+		fmt.Printf("invalid secret for transport %s, tls.crt key not found", obj)
+		return nil, fmt.Errorf("invalid secret for transport %s, tls.crt key not found", obj)
+	}
+
+	s.key = bytes.NewBuffer(key)
+	s.crt = bytes.NewBuffer(crt)
+
+	setClientContainers(s, obj)
+	createClientVolumes(s, obj)
+	s.port = stunnelPort
+	return s, nil
 }


### PR DESCRIPTION
One of the challenges in using state-lib in any controller was to re-create the in-memory objects after the related kube/openshift objects for endpoint and transport were created. 

With this state-lib now has a way to create the objects in memory by loading the information from the created objects. The Getters can be used as show in the example