### PR TITLE
Binary plugins to support minimal stateless demo.

### DIFF
--- a/transform/binary-plugin/examples/route/route.go
+++ b/transform/binary-plugin/examples/route/route.go
@@ -1,0 +1,35 @@
+package main
+
+import (
+	"fmt"
+
+	jsonpatch "github.com/evanphx/json-patch"
+	"github.com/konveyor/crane-lib/transform"
+	"github.com/konveyor/crane-lib/transform/cli"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+)
+
+func main() {
+	cli.RunAndExit(cli.NewCustomPlugin("RoutePlugin", "v1", nil, Run))
+}
+
+// Removes spec.host for host.generated Routes
+func Run(u *unstructured.Unstructured, extras map[string]string) (transform.PluginResponse, error) {
+	// plugin writers need to write custome code here.
+	var patch jsonpatch.Patch
+	var err error
+	if u.GetKind() == "Route" {
+		annotations := u.GetAnnotations()
+		if annotations != nil && annotations["openshift.io/host.generated"] == "true" {
+			patchJSON := fmt.Sprintf(`[
+{ "op": "remove", "path": "/spec/host"}
+]`)
+			patch, err = jsonpatch.DecodePatch([]byte(patchJSON))
+		}
+	}
+	return transform.PluginResponse{
+		Version:    "v1",
+		IsWhiteOut: false,
+		Patches:    patch,
+	}, err
+}

--- a/transform/binary-plugin/examples/service/service.go
+++ b/transform/binary-plugin/examples/service/service.go
@@ -1,0 +1,86 @@
+package main
+
+import (
+	"fmt"
+
+	jsonpatch "github.com/evanphx/json-patch"
+	"github.com/konveyor/crane-lib/transform"
+	"github.com/konveyor/crane-lib/transform/cli"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+)
+
+func main() {
+	cli.RunAndExit(cli.NewCustomPlugin("ServicePlugin", "v1", nil, Run))
+}
+
+// Removes ExternalIPs for LoadBalancer services
+func Run(u *unstructured.Unstructured, extras map[string]string) (transform.PluginResponse, error) {
+	// plugin writers need to write custome code here.
+	var patch jsonpatch.Patch
+	var err error
+	if u.GetKind() == "Service" {
+		var intPatch jsonpatch.Patch
+		if IsLoadBalancerService(*u) {
+			patchJSON := fmt.Sprintf(`[
+{ "op": "remove", "path": "/spec/externalIPs"}
+]`)
+			patch, err = jsonpatch.DecodePatch([]byte(patchJSON))
+		}
+		if !IsServiceClusterIPNone(*u) {
+			patchJSON := fmt.Sprintf(`[
+{ "op": "remove", "path": "/spec/clusterIP"}
+]`)
+			intPatch, err = jsonpatch.DecodePatch([]byte(patchJSON))
+			patch = append(patch, intPatch...)
+		}
+	}
+	return transform.PluginResponse{
+		Version:    "v1",
+		IsWhiteOut: false,
+		Patches:    patch,
+	}, err
+}
+
+func IsLoadBalancerService(u unstructured.Unstructured) bool {
+	if u.GetKind() != "Service" {
+		return false
+	}
+	// Get Spec
+	spec, ok := u.UnstructuredContent()["spec"]
+	if !ok {
+		return false
+	}
+
+	specMap, ok := spec.(map[string]interface{})
+	if !ok {
+		return false
+	}
+	// Get type
+	serviceType, ok := specMap["type"]
+	if !ok {
+		return false
+	}
+	return serviceType == "LoadBalancer"
+}
+
+func IsServiceClusterIPNone(u unstructured.Unstructured) bool {
+	if u.GetKind() != "Service" {
+		return false
+	}
+	// Get Spec
+	spec, ok := u.UnstructuredContent()["spec"]
+	if !ok {
+		return false
+	}
+
+	specMap, ok := spec.(map[string]interface{})
+	if !ok {
+		return false
+	}
+	// Get type
+	clusterIP, ok := specMap["clusterIP"]
+	if !ok {
+		return false
+	}
+	return clusterIP == "None"
+}

--- a/transform/binary-plugin/examples/skip-owned/skip-owned.go
+++ b/transform/binary-plugin/examples/skip-owned/skip-owned.go
@@ -1,0 +1,34 @@
+package main
+
+import (
+	jsonpatch "github.com/evanphx/json-patch"
+	"github.com/konveyor/crane-lib/transform"
+	"github.com/konveyor/crane-lib/transform/cli"
+	"github.com/konveyor/crane-lib/transform/types"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+)
+
+func main() {
+	cli.RunAndExit(cli.NewCustomPlugin("SkipOwnedResourcesPlugin", "v1", nil, Run))
+}
+
+// Skips Pods and PodSpecable resources with owner references
+// Currently doesn't check the type of owner or any labels/annotations to modify behavior.
+func Run(u *unstructured.Unstructured, extras map[string]string) (transform.PluginResponse, error) {
+	// plugin writers need to write custome code here.
+	var patch jsonpatch.Patch
+	var considerWhiteout, whiteout bool
+	if u.GetKind() == "Pod" {
+		considerWhiteout = true
+	} else if _, isPodSpecable := types.IsPodSpecable(*u); isPodSpecable {
+		considerWhiteout = true
+	}
+	if considerWhiteout && len(u.GetOwnerReferences()) > 0 {
+		whiteout = considerWhiteout
+	}
+	return transform.PluginResponse{
+		Version:    "v1",
+		IsWhiteOut: whiteout,
+		Patches:    patch,
+	}, nil
+}


### PR DESCRIPTION
Most of this functionality should eventually move to the
kubernetes and openshift plugins. The kubernetes plugin
can't be used until the first iteration of plugin management
is added, since crane transform currently only supports
binary plugins. The openshift-specific components (the route
plugin) can be integrated into the openshift binary plugin
once that has been fixed to allow disabling of individual
actions within it.