### PR TITLE
Updating kubernetes plugin with changes needed for stateless migrations

### DIFF
--- a/transform/kubernetes/kubernetes.go
+++ b/transform/kubernetes/kubernetes.go
@@ -1,32 +1,48 @@
 package kubernetes
 
 import (
+	"encoding/json"
 	"fmt"
 	"strings"
 
 	jsonpatch "github.com/evanphx/json-patch"
 	transform "github.com/konveyor/crane-lib/transform"
 	"github.com/konveyor/crane-lib/transform/types"
+	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 )
 
 const (
-	containerImageUpdate     = "/spec/template/spec/containers/%v/image"
-	initContainerImageUpdate = "/spec/template/spec/initContainers/%v/image"
-	annotationInitial        = `%v
+	containerImageUpdate        = "/spec/template/spec/containers/%v/image"
+	initContainerImageUpdate    = "/spec/template/spec/initContainers/%v/image"
+	podContainerImageUpdate     = "/spec/containers/%v/image"
+	podInitContainerImageUpdate = "/spec/initContainers/%v/image"
+	annotationInitial           = `%v
 {"op": "add", "path": "/metadata/annotations/%v", "value": "%v"}`
 	annotationNext = `%v,
 {"op": "add", "path": "/metadata/annotations/%v", "value": "%v"}`
+	removeAnnotationInitial = `%v
+{"op": "remove", "path": "/metadata/annotations/%v"}`
+	removeAnnotationNext = `%v,
+{"op": "remove", "path": "/metadata/annotations/%v"}`
 	updateImageString = `[
 {"op": "replace", "path": "%v", "value": "%v"}
 ]`
-	podSelectedNode = `[
+	podNodeName = `[
 {"op": "remove", "path": "/spec/nodeName"}
 ]`
 
+	podNodeSelector = `[
+{"op": "remove", "path": "/spec/nodeSelector"}
+]`
+
+	podPriority = `[
+{"op": "remove", "path": "/spec/priority"}
+]`
+
 	updateNamespaceString = `[
-{"op": "replace", "path": "/namespace", "value": "%v"}
+{"op": "replace", "path": "/metadata/namespace", "value": "%v"}
 ]`
 
 	updateRoleBindingSVCACCTNamspacestring = `%v
@@ -34,6 +50,10 @@ const (
 
 	updateClusterIP = `[
 {"op": "remove", "path": "/spec/clusterIP"}
+]`
+
+	updateExternalIPs = `[
+{"op": "remove", "path": "/spec/externalIPs"}
 ]`
 )
 
@@ -63,18 +83,32 @@ var serviceGK = schema.GroupKind{
 }
 
 type KubernetesTransformPlugin struct {
-	AddedAnnotations    map[string]string
+	AddAnnotations      map[string]string
+	RemoveAnnotations   []string
 	RegistryReplacement map[string]string
 	NewNamespace        string
-	RemoveAnnotation    []string
+}
+
+func (k KubernetesTransformPlugin) setOptionalFields(extras map[string]string) {
+	k.NewNamespace = extras["NewNamespace"]
+	if len(extras["AddAnnotations"]) > 0 {
+		k.AddAnnotations = transform.ParseOptionalFieldMapVal(extras["AddAnnotations"])
+	}
+	if len(extras["RemoveAnnotations"]) > 0 {
+		k.RemoveAnnotations = transform.ParseOptionalFieldSliceVal(extras["RemoveAnnotations"])
+	}
+	if len(extras["RegistryReplacement"]) > 0 {
+		k.RegistryReplacement = transform.ParseOptionalFieldMapVal(extras["RegistryReplacement"])
+	}
 }
 
 func (k KubernetesTransformPlugin) Run(u *unstructured.Unstructured, extras map[string]string) (transform.PluginResponse, error) {
+	k.setOptionalFields(extras)
 	resp := transform.PluginResponse{}
 	// Set version in the future
 	resp.Version = string(transform.V1)
 	var err error
-	resp.IsWhiteOut = k.getWhiteOuts(u.GroupVersionKind().GroupKind())
+	resp.IsWhiteOut = k.getWhiteOuts(*u)
 	if resp.IsWhiteOut {
 		return resp, err
 	}
@@ -85,20 +119,20 @@ func (k KubernetesTransformPlugin) Run(u *unstructured.Unstructured, extras map[
 
 func (k KubernetesTransformPlugin) Metadata() transform.PluginMetadata {
 	return transform.PluginMetadata{
-		Name:            updateNamespaceString,
+		Name:            "KubernetesPlugin",
 		Version:         "v1",
 		RequestVersion:  []transform.Version{transform.V1},
 		ResponseVersion: []transform.Version{transform.V1},
 		OptionalFields:  []transform.OptionalFields{
 			{
-				FlagName: "AddedAnnotations",
+				FlagName: "AddAnnotations",
 				Help:     "Annotations to add to each resource",
-				Example:  "<FIXME: annotation example>",
+				Example:  "annotation1=value1,annotation2=value2",
 			},
 			{
 				FlagName: "RegistryReplacement",
 				Help:     "Map of image registry paths to swap on transform, in the format original-registry1=target-registry1,original-registry2=target-registry2...",
-				Example:  "docker-registry.default.svc:5000=image-registry.openshift-image-registry.svc:5000",
+				Example:  "docker-registry.default.svc:5000=image-registry.openshift-image-registry.svc:5000,docker.io/foo=quay.io/bar",
 			},
 			{
 				FlagName: "NewNamespace",
@@ -106,7 +140,7 @@ func (k KubernetesTransformPlugin) Metadata() transform.PluginMetadata {
 				Example:  "destination-namespace",
 			},
 			{
-				FlagName: "RemoveAnnotation",
+				FlagName: "RemoveAnnotations",
 				Help:     "Annotations to remove",
 				Example:  "annotation1,annotation2",
 			},
@@ -116,7 +150,8 @@ func (k KubernetesTransformPlugin) Metadata() transform.PluginMetadata {
 
 var _ transform.Plugin = &KubernetesTransformPlugin{}
 
-func (k KubernetesTransformPlugin) getWhiteOuts(groupKind schema.GroupKind) bool {
+func (k KubernetesTransformPlugin) getWhiteOuts(obj unstructured.Unstructured) bool {
+	groupKind := obj.GroupVersionKind().GroupKind()
 	if groupKind == endpointGK {
 		return true
 	}
@@ -130,6 +165,10 @@ func (k KubernetesTransformPlugin) getWhiteOuts(groupKind schema.GroupKind) bool
 	if groupKind == pvcGK {
 		return true
 	}
+	_, isPodSpecable := types.IsPodSpecable(obj)
+	if (groupKind == podGK || isPodSpecable) && len(obj.GetOwnerReferences()) > 0 {
+		return true
+	}
 	return false
 }
 
@@ -137,23 +176,67 @@ func (k KubernetesTransformPlugin) getKubernetesTransforms(obj unstructured.Unst
 
 	// Always attempt to add annotations for each thing.
 	jsonPatch := jsonpatch.Patch{}
-	if len(k.AddedAnnotations) > 0 {
-		patches, err := addAnnotations(k.AddedAnnotations)
+	if k.AddAnnotations != nil && len(k.AddAnnotations) > 0 {
+		patches, err := addAnnotations(k.AddAnnotations)
+		if err != nil {
+			return nil, err
+		}
+		jsonPatch = append(jsonPatch, patches...)
+	}
+	if len(k.RemoveAnnotations) > 0 {
+		patches, err := removeAnnotations(k.RemoveAnnotations)
+		if err != nil {
+			return nil, err
+		}
+		jsonPatch = append(jsonPatch, patches...)
+	}
+	if len(k.NewNamespace) > 0 {
+		patches, err := updateNamespace(k.NewNamespace)
 		if err != nil {
 			return nil, err
 		}
 		jsonPatch = append(jsonPatch, patches...)
 	}
 	if podGK == obj.GetObjectKind().GroupVersionKind().GroupKind() {
-		patches, err := removePodSelectedNode()
+		patches, err := removePodFields()
 		if err != nil {
 			return nil, err
 		}
 		jsonPatch = append(jsonPatch, patches...)
 	}
-	if len(k.RegistryReplacement) > 0 {
+	if k.RegistryReplacement != nil && len(k.RegistryReplacement) > 0 {
 		if podGK == obj.GetObjectKind().GroupVersionKind().GroupKind() {
-			// jsonPatch for return
+			js, err := obj.MarshalJSON()
+			if err != nil {
+				return nil, err
+			}
+			pod := &v1.Pod{}
+			err = json.Unmarshal(js, pod)
+			if err != nil {
+				return nil, err
+			}
+			jps := jsonpatch.Patch{}
+			for i, container := range pod.Spec.Containers {
+				updatedImage, update := updateImageRegistry(k.RegistryReplacement, container.Image)
+				if update {
+					jp, err := updateImage(fmt.Sprintf(podContainerImageUpdate, i), updatedImage)
+					if err != nil {
+						return nil, err
+					}
+					jps = append(jps, jp...)
+				}
+			}
+			for i, container := range pod.Spec.InitContainers {
+				updatedImage, update := updateImageRegistry(k.RegistryReplacement, container.Image)
+				if update {
+					jp, err := updateImage(fmt.Sprintf(podInitContainerImageUpdate, i), updatedImage)
+					if err != nil {
+						return nil, err
+					}
+					jps = append(jps, jp...)
+				}
+			}
+			jsonPatch = append(jsonPatch, jps...)
 		} else if template, ok := types.IsPodSpecable(obj); ok {
 			jps := jsonpatch.Patch{}
 			for i, container := range template.Spec.Containers {
@@ -180,7 +263,7 @@ func (k KubernetesTransformPlugin) getKubernetesTransforms(obj unstructured.Unst
 		}
 	}
 	if obj.GetObjectKind().GroupVersionKind().GroupKind() == serviceGK {
-		patches, err := removeServiceClusterIPs()
+		patches, err := removeServiceFields(obj)
 		if err != nil {
 			return nil, err
 		}
@@ -193,24 +276,46 @@ func (k KubernetesTransformPlugin) getKubernetesTransforms(obj unstructured.Unst
 func updateImageRegistry(registryReplacements map[string]string, oldImageName string) (string, bool) {
 	// Break up oldImage to get the registry URL. Assume all manifests are using fully qualified image paths, if not ignore.
 	imageParts := strings.Split(oldImageName, "/")
-	if len(imageParts) != 3 {
-		return "", false
+	for i := len(imageParts); i > 0; i-- {
+		if replacedImageParts, ok := registryReplacements[strings.Join(imageParts[:i], "/")]; ok {
+			if i == len(imageParts) {
+				return replacedImageParts, true
+			}
+			return fmt.Sprintf("%s/%s", replacedImageParts, strings.Join(imageParts[i:], "/")), true
+		}
 	}
-	if newRegistry, ok := registryReplacements[imageParts[0]]; ok {
-		return strings.Join([]string{newRegistry, imageParts[1], imageParts[2]}, "/"), true
-	}
-
 	return "", false
 }
 
-func addAnnotations(addedAnnotations map[string]string) (jsonpatch.Patch, error) {
+func addAnnotations(addAnnotations map[string]string) (jsonpatch.Patch, error) {
 	patchJSON := `[`
 	i := 0
-	for key, value := range addedAnnotations {
+	for key, value := range addAnnotations {
 		if i == 0 {
 			patchJSON = fmt.Sprintf(annotationInitial, patchJSON, key, value)
 		} else {
 			patchJSON = fmt.Sprintf(annotationNext, patchJSON, key, value)
+		}
+		i++
+	}
+
+	patchJSON = fmt.Sprintf("%v]", patchJSON)
+	patch, err := jsonpatch.DecodePatch([]byte(patchJSON))
+	if err != nil {
+		fmt.Printf("%v", patchJSON)
+		return nil, err
+	}
+	return patch, nil
+}
+
+func removeAnnotations(removeAnnotations []string) (jsonpatch.Patch, error) {
+	patchJSON := `[`
+	i := 0
+	for _, annotation := range removeAnnotations {
+		if i == 0 {
+			patchJSON = fmt.Sprintf(removeAnnotationInitial, patchJSON, annotation)
+		} else {
+			patchJSON = fmt.Sprintf(removeAnnotationNext, patchJSON, annotation)
 		}
 		i++
 	}
@@ -234,12 +339,23 @@ func updateImage(containerImagePath, updatedImagePath string) (jsonpatch.Patch, 
 	return patch, nil
 }
 
-func removePodSelectedNode() (jsonpatch.Patch, error) {
-	patch, err := jsonpatch.DecodePatch([]byte(podSelectedNode))
+func removePodFields() (jsonpatch.Patch, error) {
+	var patches jsonpatch.Patch
+	patches, err := jsonpatch.DecodePatch([]byte(podNodeName))
 	if err != nil {
 		return nil, err
 	}
-	return patch, nil
+	patch, err := jsonpatch.DecodePatch([]byte(podNodeSelector))
+	if err != nil {
+		return nil, err
+	}
+	patches = append(patches, patch...)
+	patch, err = jsonpatch.DecodePatch([]byte(podPriority))
+	if err != nil {
+		return nil, err
+	}
+	patches = append(patches, patch...)
+	return patches, nil
 }
 
 func updateNamespace(newNamespace string) (jsonpatch.Patch, error) {
@@ -268,10 +384,60 @@ func updateRoleBindingSVCACCTNamespace(newNamespace string, numberOfSubjects int
 	return patch, nil
 }
 
-func removeServiceClusterIPs() (jsonpatch.Patch, error) {
-	patch, err := jsonpatch.DecodePatch([]byte(updateClusterIP))
-	if err != nil {
-		return nil, err
+func removeServiceFields(obj unstructured.Unstructured) (jsonpatch.Patch, error) {
+	var patches jsonpatch.Patch
+	if isLoadBalancerService(obj) {
+		patch, err := jsonpatch.DecodePatch([]byte(updateExternalIPs))
+		if err != nil {
+			return nil, err
+		}
+		patches = append(patches, patch...)
 	}
-	return patch, nil
+
+	if !isServiceClusterIPNone(obj) {
+		patch, err := jsonpatch.DecodePatch([]byte(updateClusterIP))
+		if err != nil {
+			return nil, err
+		}
+		patches = append(patches, patch...)
+	}
+	return patches, nil
+}
+
+func isLoadBalancerService(u unstructured.Unstructured) bool {
+	// Get Spec
+	spec, ok := u.UnstructuredContent()["spec"]
+	if !ok {
+		return false
+	}
+
+	specMap, ok := spec.(map[string]interface{})
+	if !ok {
+		return false
+	}
+	// Get type
+	serviceType, ok := specMap["type"]
+	if !ok {
+		return false
+	}
+	return serviceType == "LoadBalancer"
+}
+
+func isServiceClusterIPNone(u unstructured.Unstructured) bool {
+	// Get Spec
+	spec, ok := u.UnstructuredContent()["spec"]
+	if !ok {
+		return false
+	}
+
+	specMap, ok := spec.(map[string]interface{})
+	if !ok {
+		return false
+	}
+	// Get type
+	clusterIP, ok := specMap["clusterIP"]
+	if !ok {
+		return false
+	}
+	return clusterIP == "None"
 }

--- a/transform/plugin.go
+++ b/transform/plugin.go
@@ -1,6 +1,8 @@
 package transform
 
 import (
+	"strings"
+
 	jsonpatch "github.com/evanphx/json-patch"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 )
@@ -50,3 +52,21 @@ const (
 	// To notice that
 	MetadataString string = "METADATA"
 )
+
+func ParseOptionalFieldSliceVal(sliceVal string) []string {
+	return strings.Split(sliceVal,",")
+}
+
+func ParseOptionalFieldMapVal(sliceVal string) map[string]string {
+	mapVal := make(map[string]string)
+	kvPairs := strings.Split(sliceVal,",")
+	for _, kvPair := range kvPairs {
+		kvSlice := strings.Split(kvPair,"=")
+		if len(kvSlice) == 1 {
+			mapVal[kvSlice[0]] = ""
+		} else {
+			mapVal[kvSlice[0]] = kvSlice[1]
+		}
+	}
+	return mapVal
+}


### PR DESCRIPTION
Unit tests added/modified to deal with all of the changes. 

I was able to do some testing of the plugin with real data by temporarily converting it into a binary plugin in my local env, but since that involves some weirdness with the struct/func associations, this will need to be re-tested to make sure it all still works as an internal plugin once this plugin is added to the plugin list in the crane transform CLI.