### PR TITLE
Fix missing labels on the route endpoint

### DIFF
--- a/state_transfer/endpoint/route/route.go
+++ b/state_transfer/endpoint/route/route.go
@@ -198,6 +198,8 @@ func (r *RouteEndpoint) setFields(c client.Client) error {
 		return err
 	}
 
+	r.labels = route.Labels
+
 	if route.Spec.Host == "" {
 		return fmt.Errorf("route %s has empty spec.host field", r.NamespacedName())
 	}


### PR DESCRIPTION
Missing labels on the route endpoint when a route is retrieved from the cluster.