### PR TITLE
refactor plugin interface to take PluginRequest rather than obj and args

### DIFF
--- a/transform/binary-plugin/binary_plugin_test.go
+++ b/transform/binary-plugin/binary_plugin_test.go
@@ -19,7 +19,7 @@ type fakeCommandRunner struct {
 	metadataStdout, metadataStderr            []byte
 }
 
-func (f *fakeCommandRunner) Run(_ *unstructured.Unstructured, _ map[string]string, _ logrus.FieldLogger) ([]byte, []byte, error) {
+func (f *fakeCommandRunner) Run(_ transform.PluginRequest, _ logrus.FieldLogger) ([]byte, []byte, error) {
 	return f.stdout, f.stderr, f.errorRunningCommand
 }
 
@@ -342,7 +342,7 @@ func TestBinaryPlugin_Run(t *testing.T) {
 				},
 				log: logrus.New().WithField("test", tt.name),
 			}
-			got, err := b.Run(&unstructured.Unstructured{}, nil)
+			got, err := b.Run(transform.PluginRequest{Unstructured:unstructured.Unstructured{}})
 			if (err != nil) != tt.wantErr {
 				t.Errorf("Run() error = %v, wantErr %v", err, tt.wantErr)
 				return

--- a/transform/binary-plugin/examples/openshift/cmd.go
+++ b/transform/binary-plugin/examples/openshift/cmd.go
@@ -7,7 +7,6 @@ import (
 	"github.com/konveyor/crane-lib/transform"
 	"github.com/konveyor/crane-lib/transform/cli"
 	"github.com/sirupsen/logrus"
-	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 )
 
 var logger logrus.FieldLogger
@@ -59,10 +58,11 @@ func getOptionalFields(extras map[string]string) (openshiftOptionalFields, error
 	return fields, nil
 }
 
-func Run(u *unstructured.Unstructured, extras map[string]string) (transform.PluginResponse, error) {
+func Run(request transform.PluginRequest) (transform.PluginResponse, error) {
+	u := request.Unstructured
 	var patch jsonpatch.Patch
 	whiteOut := false
-	inputFields, err := getOptionalFields(extras)
+	inputFields, err := getOptionalFields(request.Extras)
 	if err != nil {
 		return transform.PluginResponse{}, err
 	}
@@ -73,16 +73,16 @@ func Run(u *unstructured.Unstructured, extras map[string]string) (transform.Plug
 		whiteOut = true
 	case "BuildConfig":
 		logger.Info("found build config, processing")
-		patch, err = UpdateBuildConfig(*u, inputFields)
+		patch, err = UpdateBuildConfig(u, inputFields)
 	case "Pod":
 		logger.Info("found pod, processing update default pull secret")
-		patch, err = UpdateDefaultPullSecrets(*u, inputFields)
+		patch, err = UpdateDefaultPullSecrets(u, inputFields)
 	case "Route":
 		logger.Info("found route, processing")
-		patch, err = UpdateRoute(*u)
+		patch, err = UpdateRoute(u)
 	case "ServiceAccount":
 		logger.Info("found service account, processing")
-		patch, err = UpdateServiceAccount(*u)
+		patch, err = UpdateServiceAccount(u)
 	}
 	if err != nil {
 		return transform.PluginResponse{}, err

--- a/transform/binary-plugin/examples/test/annotation/annotation.go
+++ b/transform/binary-plugin/examples/test/annotation/annotation.go
@@ -6,7 +6,6 @@ import (
 	jsonpatch "github.com/evanphx/json-patch"
 	"github.com/konveyor/crane-lib/transform"
 	"github.com/konveyor/crane-lib/transform/cli"
-	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 )
 
 func main() {
@@ -20,9 +19,9 @@ func main() {
 	cli.RunAndExit(cli.NewCustomPlugin("AnnotationPlugin", "v1", fields, Run))
 }
 
-func Run(u *unstructured.Unstructured, extras map[string]string) (transform.PluginResponse, error) {
+func Run(request transform.PluginRequest) (transform.PluginResponse, error) {
 	// plugin writers need to write custome code here.
-	patch, err := AddAnnotation(*u, extras)
+	patch, err := AddAnnotation(request)
 
 	if err != nil {
 		return transform.PluginResponse{}, err
@@ -34,8 +33,8 @@ func Run(u *unstructured.Unstructured, extras map[string]string) (transform.Plug
 	}, nil
 }
 
-func AddAnnotation(u unstructured.Unstructured, extras map[string]string) (jsonpatch.Patch, error) {
-	val, ok := extras["annotation-value"]
+func AddAnnotation(request transform.PluginRequest) (jsonpatch.Patch, error) {
+	val, ok := request.Extras["annotation-value"]
 	if !ok {
 		val = "crane"
 	}

--- a/transform/binary-plugin/examples/test/whiteout-all/whiteout-all.go
+++ b/transform/binary-plugin/examples/test/whiteout-all/whiteout-all.go
@@ -4,14 +4,13 @@ import (
 	jsonpatch "github.com/evanphx/json-patch"
 	"github.com/konveyor/crane-lib/transform"
 	"github.com/konveyor/crane-lib/transform/cli"
-	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 )
 
 func main() {
 	cli.RunAndExit(cli.NewCustomPlugin("WhiteoutPluginAll", "v1", nil, Run))
 }
 
-func Run(u *unstructured.Unstructured, extras map[string]string) (transform.PluginResponse, error) {
+func Run(request transform.PluginRequest) (transform.PluginResponse, error) {
 	// plugin writers need to write custome code here.
 	var patch jsonpatch.Patch
 	return transform.PluginResponse{

--- a/transform/binary-plugin/examples/test/whiteout-pods/whiteout-pods.go
+++ b/transform/binary-plugin/examples/test/whiteout-pods/whiteout-pods.go
@@ -4,18 +4,17 @@ import (
 	jsonpatch "github.com/evanphx/json-patch"
 	"github.com/konveyor/crane-lib/transform"
 	"github.com/konveyor/crane-lib/transform/cli"
-	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 )
 
 func main() {
 	cli.RunAndExit(cli.NewCustomPlugin("WhiteoutPodsPlugin", "v1", nil, Run))
 }
 
-func Run(u *unstructured.Unstructured, extras map[string]string) (transform.PluginResponse, error) {
+func Run(request transform.PluginRequest) (transform.PluginResponse, error) {
 	// plugin writers need to write custome code here.
 	var patch jsonpatch.Patch
 	var whiteout bool
-	if u.GetKind() == "Pod" {
+	if request.Unstructured.GetKind() == "Pod" {
 		whiteout = true
 	}
 	return transform.PluginResponse{

--- a/transform/cli/cli_test.go
+++ b/transform/cli/cli_test.go
@@ -63,7 +63,7 @@ func TestRunAndExit(t *testing.T) {
 		metadata       *transform.PluginMetadata
 		wantErr        bool
 		wantedErr      errors.PluginError
-		fakeFunc       func(*unstructured.Unstructured, map[string]string) (transform.PluginResponse, error)
+		fakeFunc       func(transform.PluginRequest) (transform.PluginResponse, error)
 		version        string
 		errCapture     bytes.Buffer
 		outCapture     bytes.Buffer
@@ -90,7 +90,7 @@ func TestRunAndExit(t *testing.T) {
 				IsWhiteOut: false,
 				Patches:    []jsonpatch.Operation{},
 			},
-			fakeFunc: func(u *unstructured.Unstructured, extras map[string]string) (transform.PluginResponse, error) {
+			fakeFunc: func(request transform.PluginRequest) (transform.PluginResponse, error) {
 				return transform.PluginResponse{
 					Version:    "v1",
 					IsWhiteOut: false,
@@ -152,7 +152,7 @@ func TestRunAndExit(t *testing.T) {
 				}},
 				err: nil,
 			},
-			fakeFunc: func(u *unstructured.Unstructured, extras map[string]string) (transform.PluginResponse, error) {
+			fakeFunc: func(request transform.PluginRequest) (transform.PluginResponse, error) {
 				return transform.PluginResponse{}, fmt.Errorf("invalid run")
 			},
 			errCapture: bytes.Buffer{},

--- a/transform/kubernetes/kubernetes.go
+++ b/transform/kubernetes/kubernetes.go
@@ -111,17 +111,17 @@ func (k KubernetesTransformPlugin) setOptionalFields(extras map[string]string) {
 	}
 }
 
-func (k KubernetesTransformPlugin) Run(u *unstructured.Unstructured, extras map[string]string) (transform.PluginResponse, error) {
-	k.setOptionalFields(extras)
+func (k KubernetesTransformPlugin) Run(request transform.PluginRequest) (transform.PluginResponse, error) {
+	k.setOptionalFields(request.Extras)
 	resp := transform.PluginResponse{}
 	// Set version in the future
 	resp.Version = string(transform.V1)
 	var err error
-	resp.IsWhiteOut = k.getWhiteOuts(*u)
+	resp.IsWhiteOut = k.getWhiteOuts(request.Unstructured)
 	if resp.IsWhiteOut {
 		return resp, err
 	}
-	resp.Patches, err = k.getKubernetesTransforms(*u)
+	resp.Patches, err = k.getKubernetesTransforms(request.Unstructured)
 	return resp, err
 
 }

--- a/transform/kubernetes/kubernetes_test.go
+++ b/transform/kubernetes/kubernetes_test.go
@@ -538,7 +538,7 @@ func TestRun(t *testing.T) {
 				RemoveAnnotations:    c.RemoveAnnotations,
 				DisableWhiteoutOwned: c.DisableWhiteoutOwned,
 			}
-			resp, err := p.Run(c.Object, nil)
+			resp, err := p.Run(transform.PluginRequest{Unstructured:*c.Object})
 			if err != nil && !c.ShouldError {
 				t.Error(err)
 			}

--- a/transform/plugin.go
+++ b/transform/plugin.go
@@ -9,7 +9,7 @@ import (
 
 type PluginRun interface {
 	// Determine for a given resources what the plugin is deciding to do with this
-	Run(*unstructured.Unstructured, map[string]string) (PluginResponse, error)
+	Run(PluginRequest) (PluginResponse, error)
 }
 
 type Metadata interface {
@@ -19,6 +19,11 @@ type Metadata interface {
 type Plugin interface {
 	PluginRun
 	Metadata
+}
+
+type PluginRequest struct {
+	unstructured.Unstructured `json:",inline"`
+	Extras map[string]string  `json:"extras,omitempty"`
 }
 
 type PluginResponse struct {

--- a/transform/runner.go
+++ b/transform/runner.go
@@ -68,7 +68,7 @@ func (r *Runner) Run(object unstructured.Unstructured, plugins []Plugin) (Runner
 		// We want to keep the original while we run each plugin.
 		c := object.DeepCopy()
 		// TODO: Handle Version things here
-		resp, err := plugin.Run(c, r.OptionalFlags)
+		resp, err := plugin.Run(PluginRequest{Unstructured:*c, Extras:r.OptionalFlags})
 		if err != nil {
 			//TODO: add debug level logging here
 			errs = append(errs, err)

--- a/transform/runner_test.go
+++ b/transform/runner_test.go
@@ -13,12 +13,12 @@ import (
 )
 
 type fakePlugin struct {
-	Func func(u *unstructured.Unstructured, extras map[string]string) (PluginResponse, error)
+	Func func(request PluginRequest) (PluginResponse, error)
 	name string
 }
 
-func (fp fakePlugin) Run(u *unstructured.Unstructured, extras map[string]string) (PluginResponse, error) {
-	return fp.Func(u, extras)
+func (fp fakePlugin) Run(request PluginRequest) (PluginResponse, error) {
+	return fp.Func(request)
 }
 
 func (fp fakePlugin) Metadata() PluginMetadata {
@@ -46,7 +46,7 @@ func TestRunnerRun(t *testing.T) {
 			Object: unstructured.Unstructured{},
 			Plugins: []Plugin{
 				fakePlugin{
-					Func: func(u *unstructured.Unstructured, extras map[string]string) (PluginResponse, error) {
+					Func: func(request PluginRequest) (PluginResponse, error) {
 						return PluginResponse{
 							Version:    "v1",
 							IsWhiteOut: false,
@@ -63,7 +63,7 @@ func TestRunnerRun(t *testing.T) {
 			Object: unstructured.Unstructured{},
 			Plugins: []Plugin{
 				fakePlugin{
-					Func: func(u *unstructured.Unstructured, extras map[string]string) (PluginResponse, error) {
+					Func: func(request PluginRequest) (PluginResponse, error) {
 						return PluginResponse{
 							IsWhiteOut: true,
 						}, nil
@@ -78,7 +78,7 @@ func TestRunnerRun(t *testing.T) {
 			Object: unstructured.Unstructured{},
 			Plugins: []Plugin{
 				fakePlugin{
-					Func: func(u *unstructured.Unstructured, extras map[string]string) (PluginResponse, error) {
+					Func: func(request PluginRequest) (PluginResponse, error) {
 						p, err := jsonpatch.DecodePatch([]byte(`[{"op": "add", "path": "/spec/testing", "value": "test"}]`))
 						if err != nil {
 							return PluginResponse{}, err
@@ -97,7 +97,7 @@ func TestRunnerRun(t *testing.T) {
 			Object: unstructured.Unstructured{},
 			Plugins: []Plugin{
 				fakePlugin{
-					Func: func(u *unstructured.Unstructured, extras map[string]string) (PluginResponse, error) {
+					Func: func(request PluginRequest) (PluginResponse, error) {
 						return PluginResponse{}, fmt.Errorf("Adding a new error to test handling of error")
 					},
 					name: "",
@@ -115,8 +115,8 @@ func TestRunnerRun(t *testing.T) {
 			},
 			Plugins: []Plugin{
 				fakePlugin{
-					Func: func(u *unstructured.Unstructured, extras map[string]string) (PluginResponse, error) {
-						u.SetGroupVersionKind(schema.GroupVersionKind{
+					Func: func(request PluginRequest) (PluginResponse, error) {
+						request.Unstructured.SetGroupVersionKind(schema.GroupVersionKind{
 							Group:   "group.testing.io",
 							Version: "v1",
 							Kind:    "Test",
@@ -126,13 +126,13 @@ func TestRunnerRun(t *testing.T) {
 					name: "",
 				},
 				fakePlugin{
-					Func: func(u *unstructured.Unstructured, extras map[string]string) (PluginResponse, error) {
+					Func: func(request PluginRequest) (PluginResponse, error) {
 						gvk := schema.GroupVersionKind{
 							Group:   "group.testing.io",
 							Version: "v1alpha1",
 							Kind:    "Test",
 						}
-						if u.GroupVersionKind() == gvk {
+						if request.Unstructured.GroupVersionKind() == gvk {
 							return PluginResponse{}, nil
 						}
 						return PluginResponse{}, fmt.Errorf("Plugin was able to change the object")
@@ -147,7 +147,7 @@ func TestRunnerRun(t *testing.T) {
 			Object: unstructured.Unstructured{},
 			Plugins: []Plugin{
 				fakePlugin{
-					Func: func(u *unstructured.Unstructured, extras map[string]string) (PluginResponse, error) {
+					Func: func(request PluginRequest) (PluginResponse, error) {
 						p, err := jsonpatch.DecodePatch([]byte(`[{"op": "add", "path": "/spec/testing", "value": "test"}]`))
 						if err != nil {
 							return PluginResponse{}, err
@@ -159,7 +159,7 @@ func TestRunnerRun(t *testing.T) {
 					name: "",
 				},
 				fakePlugin{
-					Func: func(u *unstructured.Unstructured, extras map[string]string) (PluginResponse, error) {
+					Func: func(request PluginRequest) (PluginResponse, error) {
 						p, err := jsonpatch.DecodePatch([]byte(`[{"op": "add", "path": "/spec/newValue", "value": "test"}]`))
 						if err != nil {
 							return PluginResponse{}, err
@@ -178,7 +178,7 @@ func TestRunnerRun(t *testing.T) {
 			Object: unstructured.Unstructured{},
 			Plugins: []Plugin{
 				fakePlugin{
-					Func: func(u *unstructured.Unstructured, extras map[string]string) (PluginResponse, error) {
+					Func: func(request PluginRequest) (PluginResponse, error) {
 						p, err := jsonpatch.DecodePatch([]byte(`[{"op": "add", "path": "/spec/testing", "value": "test"}]`))
 						if err != nil {
 							return PluginResponse{}, err
@@ -190,7 +190,7 @@ func TestRunnerRun(t *testing.T) {
 					name: "",
 				},
 				fakePlugin{
-					Func: func(u *unstructured.Unstructured, extras map[string]string) (PluginResponse, error) {
+					Func: func(request PluginRequest) (PluginResponse, error) {
 						p, err := jsonpatch.DecodePatch([]byte(`[{"op": "add", "path": "/spec/testing", "value": "test"}]`))
 						if err != nil {
 							return PluginResponse{}, err
@@ -209,7 +209,7 @@ func TestRunnerRun(t *testing.T) {
 			Object: unstructured.Unstructured{},
 			Plugins: []Plugin{
 				fakePlugin{
-					Func: func(u *unstructured.Unstructured, extras map[string]string) (PluginResponse, error) {
+					Func: func(request PluginRequest) (PluginResponse, error) {
 						p, err := jsonpatch.DecodePatch([]byte(`[{"op": "add", "path": "/spec/testing", "value": "test"}]`))
 						if err != nil {
 							return PluginResponse{}, err
@@ -221,7 +221,7 @@ func TestRunnerRun(t *testing.T) {
 					name: "plugin1",
 				},
 				fakePlugin{
-					Func: func(u *unstructured.Unstructured, extras map[string]string) (PluginResponse, error) {
+					Func: func(request PluginRequest) (PluginResponse, error) {
 						p, err := jsonpatch.DecodePatch([]byte(`[{"op": "add", "path": "/spec/testing", "value": "test1"}]`))
 						if err != nil {
 							return PluginResponse{}, err
@@ -241,7 +241,7 @@ func TestRunnerRun(t *testing.T) {
 			Object: unstructured.Unstructured{},
 			Plugins: []Plugin{
 				fakePlugin{
-					Func: func(u *unstructured.Unstructured, extras map[string]string) (PluginResponse, error) {
+					Func: func(request PluginRequest) (PluginResponse, error) {
 						p, err := jsonpatch.DecodePatch([]byte(`[{"op": "add", "path": "/spec/testing", "value": "test"}]`))
 						if err != nil {
 							return PluginResponse{}, err
@@ -253,7 +253,7 @@ func TestRunnerRun(t *testing.T) {
 					name: "plugin1",
 				},
 				fakePlugin{
-					Func: func(u *unstructured.Unstructured, extras map[string]string) (PluginResponse, error) {
+					Func: func(request PluginRequest) (PluginResponse, error) {
 						p, err := jsonpatch.DecodePatch([]byte(`[{"op": "add", "path": "/spec/testing", "value": "test1"}]`))
 						if err != nil {
 							return PluginResponse{}, err
@@ -276,7 +276,7 @@ func TestRunnerRun(t *testing.T) {
 			Object: unstructured.Unstructured{},
 			Plugins: []Plugin{
 				fakePlugin{
-					Func: func(u *unstructured.Unstructured, extras map[string]string) (PluginResponse, error) {
+					Func: func(request PluginRequest) (PluginResponse, error) {
 					p, err := jsonpatch.DecodePatch([]byte(`[{"op": "replace", "path": "/spec/testing", "value": "test"}]`))
 					if err != nil {
 						return PluginResponse{}, err
@@ -288,7 +288,7 @@ func TestRunnerRun(t *testing.T) {
 					name: "pluginreplace",
 				},
 				fakePlugin{
-					Func: func(u *unstructured.Unstructured, extras map[string]string) (PluginResponse, error) {
+					Func: func(request PluginRequest) (PluginResponse, error) {
 					p, err := jsonpatch.DecodePatch([]byte(`[{"op": "remove", "path": "/spec/testing"}]`))
 					if err != nil {
 						return PluginResponse{}, err
@@ -308,8 +308,8 @@ func TestRunnerRun(t *testing.T) {
 			Object: unstructured.Unstructured{},
 			Plugins: []Plugin{
 				fakePlugin{
-					Func: func(u *unstructured.Unstructured, extras map[string]string) (PluginResponse, error) {
-						extraVal := extras["testFlag"]
+					Func: func(request PluginRequest) (PluginResponse, error) {
+						extraVal := request.Extras["testFlag"]
 						p, err := jsonpatch.DecodePatch([]byte(`[{"op": "add", "path": "/spec/testing", "value": "` + extraVal + `"}]`))
 					if err != nil {
 						return PluginResponse{}, err


### PR DESCRIPTION

Refactor plugin interface to take PluginRequest rather than separate obj and args.
This allows for sending raw object json to a binary plugin for testing without
an expected separate line of entry for optional args.