### PR TITLE
Fixes for plugin optional args

### DIFF
--- a/transform/binary-plugin/examples/openshift/cmd.go
+++ b/transform/binary-plugin/examples/openshift/cmd.go
@@ -11,22 +11,29 @@ import (
 
 var logger logrus.FieldLogger
 
+const (
+	// flags
+	StripDefaultPullSecrets = "strip-default-pull-secrets"
+	PullSecretReplacement   = "pull-secret-replacement"
+	RegistryReplacement     = "registry-replacement"
+)
+
 func main() {
 	logger = logrus.New()
 	// TODO: add plumbing for logger in the cli-library and instantiate here
 	fields := []transform.OptionalFields{
                 {
-                        FlagName: "StripDefaultPullSecrets",
-                        Help:     "Whether to strip Pod and BuildConfig default pull secrets (beginning with builder/default/deployer-dockercfg-) that aren't replaced by the map param PullSecretReplacement",
+                        FlagName: StripDefaultPullSecrets,
+                        Help:     "Whether to strip Pod and BuildConfig default pull secrets (beginning with builder/default/deployer-dockercfg-) that aren't replaced by the map param " + PullSecretReplacement,
                         Example:  "true",
                 },
                 {
-                        FlagName: "PullSecretReplacement",
+                        FlagName: PullSecretReplacement,
                         Help:     "Map of pull secrets to replace in Pods and BuildConfigs while transforming in format secret1=destsecret1,secret2=destsecret2[...]",
 			Example:  "default-dockercfg-h4n7g=default-dockercfg-12345,builder-dockercfg-abcde=builder-dockercfg-12345",
                 },
 		{
-			FlagName: "RegistryReplacement",
+			FlagName: RegistryReplacement,
 			Help:     "Map of image registry paths to swap on transform, in the format original-registry1=target-registry1,original-registry2=target-registry2...",
 			Example:  "docker-registry.default.svc:5000=image-registry.openshift-image-registry.svc:5000,docker.io/foo=quay.io/bar",
 		},
@@ -43,17 +50,17 @@ type openshiftOptionalFields struct {
 func getOptionalFields(extras map[string]string) (openshiftOptionalFields, error) {
 	var fields openshiftOptionalFields
 	var err error
-	if len(extras["StripDefaultPullSecrets"]) > 0 {
-		fields.StripDefaultPullSecrets, err = strconv.ParseBool(extras["StripDefaultPullSecrets"])
+	if len(extras[StripDefaultPullSecrets]) > 0 {
+		fields.StripDefaultPullSecrets, err = strconv.ParseBool(extras[StripDefaultPullSecrets])
 		if err != nil {
 			return fields, err
 		}
 	}
-	if len(extras["PullSecretReplacement"]) > 0 {
-		fields.PullSecretReplacement = transform.ParseOptionalFieldMapVal(extras["PullSecretReplacement"])
+	if len(extras[PullSecretReplacement]) > 0 {
+		fields.PullSecretReplacement = transform.ParseOptionalFieldMapVal(extras[PullSecretReplacement])
 	}
-	if len(extras["RegistryReplacement"]) > 0 {
-		fields.RegistryReplacement = transform.ParseOptionalFieldMapVal(extras["RegistryReplacement"])
+	if len(extras[RegistryReplacement]) > 0 {
+		fields.RegistryReplacement = transform.ParseOptionalFieldMapVal(extras[RegistryReplacement])
 	}
 	return fields, nil
 }


### PR DESCRIPTION
    1) Use struct pointer for KubernetesTransformPlugin funcs
    2) Fix binary plugin marshal code to properly encode args
    3) Use lower-cased arg names/keys
