### PR TITLE
Bug 2021666: handle routes longer than 63 chars

### DIFF
--- a/state_transfer/example_test.go
+++ b/state_transfer/example_test.go
@@ -79,7 +79,7 @@ func Example_basicTransfer() {
 		types.NamespacedName{
 			Namespace: pvc.Name,
 			Name:      pvc.Namespace,
-		}, route.EndpointTypePassthrough, statetransfermeta.Labels)
+		}, route.EndpointTypePassthrough, statetransfermeta.Labels, "")
 	e, err := endpoint.Create(r, destClient)
 	if err != nil {
 		log.Fatal(err, "unable to create route endpoint")


### PR DESCRIPTION
  With this change when a subdomain is specified, we can ensure the host portion of the route.spec.host is less than 63 characters.