### PR TITLE
Bug 2021668: set route host when subdomain specified

### DIFF
--- a/state_transfer/endpoint/route/route.go
+++ b/state_transfer/endpoint/route/route.go
@@ -184,6 +184,9 @@ func (r *RouteEndpoint) createRoute(c client.Client) error {
 		if len(routePrefix) > 62 {
 			routePrefix = routePrefix[0:62]
 		}
+	}
+
+	if r.subdomain != "" {
 		route.Spec.Host = routePrefix + "." + r.subdomain
 	}
 


### PR DESCRIPTION
It turns out that the route controller doesn't really respect the subdomain setting on the route. Updating crane-lib so that whenever the subdomain is set (ie. `subdomain != ""`) we will set the route's host directly.