### PR TITLE
Update kubernetes plugin for Job selectors

### DIFF
--- a/transform/kubernetes/kubernetes.go
+++ b/transform/kubernetes/kubernetes.go
@@ -74,6 +74,8 @@ var fieldsToStrip = [...][]string{
 	{metadata, "generation"},
 	{metadata, "managedFields"},
 	{metadata, "annotations", "kubectl.kubernetes.io/last-applied-configuration"},
+	{metadata, "annotations", "batch.kubernetes.io/controller-uid"},
+	{metadata, "labels", "batch.kubernetes.io/controller-uid"},
 	{"status"},
 }
 
@@ -417,6 +419,12 @@ func (k *KubernetesTransformPlugin) getKubernetesTransforms(obj unstructured.Uns
 		}
 
 		patches, err := util.RenamePVCs(job.Spec.Template.Spec.Volumes, k.PVCRenameMap, util.PVCPathGenericString)
+		if err != nil {
+			return nil, err
+		}
+		jsonPatch = append(jsonPatch, patches...)
+
+		patches, err = removeJobControllerUID(obj)
 		if err != nil {
 			return nil, err
 		}
@@ -912,4 +920,60 @@ func getNodePortInt(nodePort interface{}) (int, error) {
 		}
 	}
 	return nodePortInt, nil
+}
+
+func removeJobControllerUID(obj unstructured.Unstructured) (jsonpatch.Patch, error) {
+	var patches jsonpatch.Patch
+
+	// Check manualSelector value
+	manualSelector, found, err := unstructured.NestedBool(obj.Object, "spec", "manualSelector")
+	if err != nil {
+		return patches, err
+	}
+
+	// If manualSelector is false or not set, remove the entire spec.selector
+	// Kubernetes will auto-generate it
+	if !found || !manualSelector {
+		_, selectorFound, err := unstructured.NestedMap(obj.Object, "spec", "selector")
+		if err != nil {
+			return patches, err
+		}
+		if selectorFound {
+			patch, err := jsonpatch.DecodePatch([]byte(fmt.Sprintf(opRemove, "/spec/selector")))
+			if err != nil {
+				return nil, err
+			}
+			patches = append(patches, patch...)
+		}
+	} else {
+		// If manualSelector is true, only remove the controller-uid from matchLabels
+		_, found, err := unstructured.NestedString(obj.Object, "spec", "selector", "matchLabels", "batch.kubernetes.io/controller-uid")
+		if err != nil {
+			return patches, err
+		}
+		if found {
+			path := "/spec/selector/matchLabels/" + escapeJSONPointer("batch.kubernetes.io/controller-uid")
+			patch, err := jsonpatch.DecodePatch([]byte(fmt.Sprintf(opRemove, path)))
+			if err != nil {
+				return nil, err
+			}
+			patches = append(patches, patch...)
+		}
+	}
+
+	// Remove controller-uid from spec.template.metadata.labels
+	_, found, err = unstructured.NestedString(obj.Object, "spec", "template", "metadata", "labels", "batch.kubernetes.io/controller-uid")
+	if err != nil {
+		return patches, err
+	}
+	if found {
+		path := "/spec/template/metadata/labels/" + escapeJSONPointer("batch.kubernetes.io/controller-uid")
+		patch, err := jsonpatch.DecodePatch([]byte(fmt.Sprintf(opRemove, path)))
+		if err != nil {
+			return nil, err
+		}
+		patches = append(patches, patch...)
+	}
+
+	return patches, nil
 }

--- a/transform/kubernetes/kubernetes.go
+++ b/transform/kubernetes/kubernetes.go
@@ -75,7 +75,9 @@ var fieldsToStrip = [...][]string{
 	{metadata, "managedFields"},
 	{metadata, "annotations", "kubectl.kubernetes.io/last-applied-configuration"},
 	{metadata, "annotations", "batch.kubernetes.io/controller-uid"},
+	{metadata, "annotations", "controller-uid"},
 	{metadata, "labels", "batch.kubernetes.io/controller-uid"},
+	{metadata, "labels", "controller-uid"},
 	{"status"},
 }
 
@@ -925,6 +927,12 @@ func getNodePortInt(nodePort interface{}) (int, error) {
 func removeJobControllerUID(obj unstructured.Unstructured) (jsonpatch.Patch, error) {
 	var patches jsonpatch.Patch
 
+	// Controller UID keys to remove (both legacy and current)
+	controllerUIDKeys := []string{
+		"batch.kubernetes.io/controller-uid",
+		"controller-uid",
+	}
+
 	// Check manualSelector value
 	manualSelector, found, err := unstructured.NestedBool(obj.Object, "spec", "manualSelector")
 	if err != nil {
@@ -946,33 +954,37 @@ func removeJobControllerUID(obj unstructured.Unstructured) (jsonpatch.Patch, err
 			patches = append(patches, patch...)
 		}
 	} else {
-		// If manualSelector is true, only remove the controller-uid from matchLabels
-		_, found, err := unstructured.NestedString(obj.Object, "spec", "selector", "matchLabels", "batch.kubernetes.io/controller-uid")
+		// If manualSelector is true, remove both controller-uid keys from matchLabels
+		for _, key := range controllerUIDKeys {
+			_, found, err := unstructured.NestedString(obj.Object, "spec", "selector", "matchLabels", key)
+			if err != nil {
+				return patches, err
+			}
+			if found {
+				path := "/spec/selector/matchLabels/" + escapeJSONPointer(key)
+				patch, err := jsonpatch.DecodePatch([]byte(fmt.Sprintf(opRemove, path)))
+				if err != nil {
+					return nil, err
+				}
+				patches = append(patches, patch...)
+			}
+		}
+	}
+
+	// Remove both controller-uid keys from spec.template.metadata.labels
+	for _, key := range controllerUIDKeys {
+		_, found, err := unstructured.NestedString(obj.Object, "spec", "template", "metadata", "labels", key)
 		if err != nil {
 			return patches, err
 		}
 		if found {
-			path := "/spec/selector/matchLabels/" + escapeJSONPointer("batch.kubernetes.io/controller-uid")
+			path := "/spec/template/metadata/labels/" + escapeJSONPointer(key)
 			patch, err := jsonpatch.DecodePatch([]byte(fmt.Sprintf(opRemove, path)))
 			if err != nil {
 				return nil, err
 			}
 			patches = append(patches, patch...)
 		}
-	}
-
-	// Remove controller-uid from spec.template.metadata.labels
-	_, found, err = unstructured.NestedString(obj.Object, "spec", "template", "metadata", "labels", "batch.kubernetes.io/controller-uid")
-	if err != nil {
-		return patches, err
-	}
-	if found {
-		path := "/spec/template/metadata/labels/" + escapeJSONPointer("batch.kubernetes.io/controller-uid")
-		patch, err := jsonpatch.DecodePatch([]byte(fmt.Sprintf(opRemove, path)))
-		if err != nil {
-			return nil, err
-		}
-		patches = append(patches, patch...)
 	}
 
 	return patches, nil

--- a/transform/kubernetes/kubernetes_test.go
+++ b/transform/kubernetes/kubernetes_test.go
@@ -680,6 +680,130 @@ func TestRun(t *testing.T) {
 			},
 			PatchResponseJson: `[{"op":"remove","path":"/metadata/annotations/kubectl.kubernetes.io~1last-applied-configuration"},{"op": "remove", "path": "/spec/ports/1/nodePort"}]`,
 		},
+		{
+			Name: "RemoveBatchControllerUIDFromJobWithManualSelectorFalse",
+			Object: &unstructured.Unstructured{
+				Object: map[string]interface{}{
+					"kind":       "Job",
+					"apiVersion": "batch/v1",
+					"metadata": map[string]interface{}{
+						"name":      "wordpress-install",
+						"namespace": "new-migrated-namespace",
+						"labels": map[string]interface{}{
+							"batch.kubernetes.io/controller-uid": "be719474-856d-4d84-80ad-4f4ab9ecdd30",
+							"batch.kubernetes.io/job-name":       "wordpress-install",
+							"migrated-with":                      "crane",
+						},
+						"annotations": map[string]interface{}{
+							"batch.kubernetes.io/controller-uid": "be719474-856d-4d84-80ad-4f4ab9ecdd30",
+							"other-annotation":                   "keep-this",
+						},
+					},
+					"spec": map[string]interface{}{
+						"manualSelector": false,
+						"selector": map[string]interface{}{
+							"matchLabels": map[string]interface{}{
+								"batch.kubernetes.io/controller-uid": "be719474-856d-4d84-80ad-4f4ab9ecdd30",
+								"migrated-with":                      "crane",
+							},
+						},
+						"template": map[string]interface{}{
+							"metadata": map[string]interface{}{
+								"labels": map[string]interface{}{
+									"batch.kubernetes.io/controller-uid": "be719474-856d-4d84-80ad-4f4ab9ecdd30",
+									"batch.kubernetes.io/job-name":       "wordpress-install",
+									"migrated-with":                      "crane",
+								},
+							},
+						},
+					},
+				},
+			},
+			Response: transform.PluginResponse{
+				IsWhiteOut: false,
+				Version:    "v1",
+			},
+			PatchResponseJson: `[{"op":"remove","path":"/metadata/annotations/batch.kubernetes.io~1controller-uid"},{"op":"remove","path":"/metadata/labels/batch.kubernetes.io~1controller-uid"},{"op":"remove","path":"/spec/selector"},{"op":"remove","path":"/spec/template/metadata/labels/batch.kubernetes.io~1controller-uid"}]`,
+		},
+		{
+			Name: "RemoveBatchControllerUIDFromJobWithManualSelectorTrue",
+			Object: &unstructured.Unstructured{
+				Object: map[string]interface{}{
+					"kind":       "Job",
+					"apiVersion": "batch/v1",
+					"metadata": map[string]interface{}{
+						"name":      "custom-job",
+						"namespace": "test-namespace",
+						"labels": map[string]interface{}{
+							"batch.kubernetes.io/controller-uid": "be719474-856d-4d84-80ad-4f4ab9ecdd30",
+							"custom-label":                       "value",
+						},
+						"annotations": map[string]interface{}{
+							"batch.kubernetes.io/controller-uid": "be719474-856d-4d84-80ad-4f4ab9ecdd30",
+						},
+					},
+					"spec": map[string]interface{}{
+						"manualSelector": true,
+						"selector": map[string]interface{}{
+							"matchLabels": map[string]interface{}{
+								"batch.kubernetes.io/controller-uid": "be719474-856d-4d84-80ad-4f4ab9ecdd30",
+								"custom-label":                       "value",
+							},
+						},
+						"template": map[string]interface{}{
+							"metadata": map[string]interface{}{
+								"labels": map[string]interface{}{
+									"batch.kubernetes.io/controller-uid": "be719474-856d-4d84-80ad-4f4ab9ecdd30",
+									"custom-label":                       "value",
+								},
+							},
+						},
+					},
+				},
+			},
+			Response: transform.PluginResponse{
+				IsWhiteOut: false,
+				Version:    "v1",
+			},
+			PatchResponseJson: `[{"op":"remove","path":"/metadata/annotations/batch.kubernetes.io~1controller-uid"},{"op":"remove","path":"/metadata/labels/batch.kubernetes.io~1controller-uid"},{"op":"remove","path":"/spec/selector/matchLabels/batch.kubernetes.io~1controller-uid"},{"op":"remove","path":"/spec/template/metadata/labels/batch.kubernetes.io~1controller-uid"}]`,
+		},
+		{
+			Name: "RemoveBatchControllerUIDFromJobWithoutManualSelector",
+			Object: &unstructured.Unstructured{
+				Object: map[string]interface{}{
+					"kind":       "Job",
+					"apiVersion": "batch/v1",
+					"metadata": map[string]interface{}{
+						"name":      "auto-selector-job",
+						"namespace": "test-namespace",
+						"labels": map[string]interface{}{
+							"batch.kubernetes.io/controller-uid": "be719474-856d-4d84-80ad-4f4ab9ecdd30",
+						},
+					},
+					"spec": map[string]interface{}{
+						"selector": map[string]interface{}{
+							"matchLabels": map[string]interface{}{
+								"batch.kubernetes.io/controller-uid": "be719474-856d-4d84-80ad-4f4ab9ecdd30",
+								"app": "test",
+							},
+						},
+						"template": map[string]interface{}{
+							"metadata": map[string]interface{}{
+								"labels": map[string]interface{}{
+									"batch.kubernetes.io/controller-uid": "be719474-856d-4d84-80ad-4f4ab9ecdd30",
+									"app": "test",
+								},
+							},
+						},
+					},
+				},
+			},
+			Response: transform.PluginResponse{
+				IsWhiteOut: false,
+				Version:    "v1",
+			},
+			PatchResponseJson: `[{"op":"remove","path":"/metadata/labels/batch.kubernetes.io~1controller-uid"},{"op":"remove","path":"/spec/selector"},{"op":"remove","path":"/spec/template/metadata/labels/batch.kubernetes.io~1controller-uid"}]`,
+		},
 	}
 
 	for _, c := range cases {

--- a/transform/kubernetes/kubernetes_test.go
+++ b/transform/kubernetes/kubernetes_test.go
@@ -804,6 +804,94 @@ func TestRun(t *testing.T) {
 			},
 			PatchResponseJson: `[{"op":"remove","path":"/metadata/labels/batch.kubernetes.io~1controller-uid"},{"op":"remove","path":"/spec/selector"},{"op":"remove","path":"/spec/template/metadata/labels/batch.kubernetes.io~1controller-uid"}]`,
 		},
+		{
+			Name: "RemoveLegacyControllerUIDFromJob",
+			Object: &unstructured.Unstructured{
+				Object: map[string]interface{}{
+					"kind":       "Job",
+					"apiVersion": "batch/v1",
+					"metadata": map[string]interface{}{
+						"name":      "legacy-job",
+						"namespace": "test-namespace",
+						"labels": map[string]interface{}{
+							"controller-uid": "be719474-856d-4d84-80ad-4f4ab9ecdd30",
+							"job-name":       "legacy-job",
+						},
+						"annotations": map[string]interface{}{
+							"controller-uid": "be719474-856d-4d84-80ad-4f4ab9ecdd30",
+						},
+					},
+					"spec": map[string]interface{}{
+						"manualSelector": true,
+						"selector": map[string]interface{}{
+							"matchLabels": map[string]interface{}{
+								"controller-uid": "be719474-856d-4d84-80ad-4f4ab9ecdd30",
+								"job-name":       "legacy-job",
+							},
+						},
+						"template": map[string]interface{}{
+							"metadata": map[string]interface{}{
+								"labels": map[string]interface{}{
+									"controller-uid": "be719474-856d-4d84-80ad-4f4ab9ecdd30",
+									"job-name":       "legacy-job",
+								},
+							},
+						},
+					},
+				},
+			},
+			Response: transform.PluginResponse{
+				IsWhiteOut: false,
+				Version:    "v1",
+			},
+			PatchResponseJson: `[{"op":"remove","path":"/metadata/annotations/controller-uid"},{"op":"remove","path":"/metadata/labels/controller-uid"},{"op":"remove","path":"/spec/selector/matchLabels/controller-uid"},{"op":"remove","path":"/spec/template/metadata/labels/controller-uid"}]`,
+		},
+		{
+			Name: "RemoveBothControllerUIDKeysFromJob",
+			Object: &unstructured.Unstructured{
+				Object: map[string]interface{}{
+					"kind":       "Job",
+					"apiVersion": "batch/v1",
+					"metadata": map[string]interface{}{
+						"name":      "mixed-job",
+						"namespace": "test-namespace",
+						"labels": map[string]interface{}{
+							"batch.kubernetes.io/controller-uid": "be719474-856d-4d84-80ad-4f4ab9ecdd30",
+							"controller-uid":                     "be719474-856d-4d84-80ad-4f4ab9ecdd30",
+							"app":                                "test",
+						},
+						"annotations": map[string]interface{}{
+							"batch.kubernetes.io/controller-uid": "be719474-856d-4d84-80ad-4f4ab9ecdd30",
+							"controller-uid":                     "be719474-856d-4d84-80ad-4f4ab9ecdd30",
+						},
+					},
+					"spec": map[string]interface{}{
+						"manualSelector": true,
+						"selector": map[string]interface{}{
+							"matchLabels": map[string]interface{}{
+								"batch.kubernetes.io/controller-uid": "be719474-856d-4d84-80ad-4f4ab9ecdd30",
+								"controller-uid":                     "be719474-856d-4d84-80ad-4f4ab9ecdd30",
+								"app":                                "test",
+							},
+						},
+						"template": map[string]interface{}{
+							"metadata": map[string]interface{}{
+								"labels": map[string]interface{}{
+									"batch.kubernetes.io/controller-uid": "be719474-856d-4d84-80ad-4f4ab9ecdd30",
+									"controller-uid":                     "be719474-856d-4d84-80ad-4f4ab9ecdd30",
+									"app":                                "test",
+								},
+							},
+						},
+					},
+				},
+			},
+			Response: transform.PluginResponse{
+				IsWhiteOut: false,
+				Version:    "v1",
+			},
+			PatchResponseJson: `[{"op":"remove","path":"/metadata/annotations/batch.kubernetes.io~1controller-uid"},{"op":"remove","path":"/metadata/annotations/controller-uid"},{"op":"remove","path":"/metadata/labels/batch.kubernetes.io~1controller-uid"},{"op":"remove","path":"/metadata/labels/controller-uid"},{"op":"remove","path":"/spec/selector/matchLabels/batch.kubernetes.io~1controller-uid"},{"op":"remove","path":"/spec/selector/matchLabels/controller-uid"},{"op":"remove","path":"/spec/template/metadata/labels/batch.kubernetes.io~1controller-uid"},{"op":"remove","path":"/spec/template/metadata/labels/controller-uid"}]`,
+		},
 	}
 
 	for _, c := range cases {


### PR DESCRIPTION
Addressing The output.yaml Job spec contains manualSelector: false with an explicit spec.selector bearing source cluster UIDs (batch.kubernetes.io/controller-uid, controller-uid). This configuration fails Kubernetes API validation with: Job.batch "wordpress-install" is invalid: spec.selector: Invalid value: ... : selector not auto-generated. When manualSelector: false, Kubernetes rejects explicit selectors; it only accepts auto-generated ones.

Related to https://github.com/migtools/crane/issues/308

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced Kubernetes Job transformation to remove both current and legacy controller-UID identifiers from job metadata, pod template labels, and selector settings, with selector cleanup behavior respecting manual selector configuration and applied after PVC renaming.

* **Tests**
  * Added comprehensive test scenarios covering removal of current and legacy controller-UID keys across metadata, selector, and template permutations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/migtools/crane-lib/pull/138?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->