### PR TITLE
[BUILD-1578] feat: map BuildConfig NoCache flag to Shipwright no-cache param

### DIFF
--- a/convert/buildconfigs.go
+++ b/convert/buildconfigs.go
@@ -111,7 +111,15 @@ func (t *ConvertOptions) convertBuildConfigs() error {
 
 			// process NoCache field
 			if bc.Spec.Strategy.DockerStrategy.NoCache {
-				t.Logger.Warnf("NoCache flag is not yet supported in the built-in Buildah ClusterBuildStrategy in Shipwright. RFE: %s", NoCacheFlagRFE)
+				t.Logger.Infof("Mapping NoCache flag to no-cache param for BuildConfig %s", bc.Name)
+				noCacheValue := "true"
+				noCacheParam := shipwrightv1beta1.ParamValue{
+					Name: "no-cache",
+					SingleValue: &shipwrightv1beta1.SingleValue{
+						Value: &noCacheValue,
+					},
+				}
+				b.Spec.ParamValues = append(b.Spec.ParamValues, noCacheParam)
 			}
 
 			// process env fields

--- a/convert/buildconfigs.go
+++ b/convert/buildconfigs.go
@@ -39,6 +39,9 @@ const (
 	GitHTTPSProxy = "HTTPS_PROXY"
 	GitNoProxy    = "NO_PROXY"
 
+	// Docker Strategy Parameters
+	NoCacheParamName = "no-cache"
+
 	Timeout = 10 * time.Minute
 )
 
@@ -110,17 +113,7 @@ func (t *ConvertOptions) convertBuildConfigs() error {
 			}
 
 			// process NoCache field
-			if bc.Spec.Strategy.DockerStrategy.NoCache {
-				t.Logger.Infof("Mapping NoCache flag to no-cache param for BuildConfig %s", bc.Name)
-				noCacheValue := "true"
-				noCacheParam := shipwrightv1beta1.ParamValue{
-					Name: "no-cache",
-					SingleValue: &shipwrightv1beta1.SingleValue{
-						Value: &noCacheValue,
-					},
-				}
-				b.Spec.ParamValues = append(b.Spec.ParamValues, noCacheParam)
-			}
+			t.processDockerStrategyNoCache(&bc, b)
 
 			// process env fields
 			if bc.Spec.Strategy.DockerStrategy.Env != nil {
@@ -895,6 +888,21 @@ func (t *ConvertOptions) processBuildArgs(bc buildv1.BuildConfig, b *shipwrightv
 		b.Spec.ParamValues = append(b.Spec.ParamValues, buildArgsParam)
 	}
 }
+
+func (t *ConvertOptions) processDockerStrategyNoCache(bc *buildv1.BuildConfig, b *shipwrightv1beta1.Build) {
+	if bc.Spec.Strategy.DockerStrategy.NoCache {
+		t.Logger.Infof("Mapping NoCache flag to no-cache param for BuildConfig %s", bc.Name)
+		noCacheValue := "true"
+		noCacheParam := shipwrightv1beta1.ParamValue{
+			Name: NoCacheParamName,
+			SingleValue: &shipwrightv1beta1.SingleValue{
+				Value: &noCacheValue,
+			},
+		}
+		b.Spec.ParamValues = append(b.Spec.ParamValues, noCacheParam)
+	}
+}
+
 
 func getBuildFilePath(b shipwrightv1beta1.Build) string {
 	return strings.Join([]string{b.GroupVersionKind().Kind, b.GroupVersionKind().Group, b.GroupVersionKind().Version, b.Namespace, b.Name}, "_") + ".yaml"

--- a/convert/buildconfigs_test.go
+++ b/convert/buildconfigs_test.go
@@ -304,6 +304,50 @@ func TestProcessOutput(t *testing.T) {
 			expectedImage: "image-registry.openshift-image-registry.svc:5000/default/output-image:latest",
 		},
 		{
+			name: "ImageStreamTag output with pushSecret",
+			buildConfig: buildv1.BuildConfig{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-bc",
+					Namespace: "default",
+				},
+				Spec: buildv1.BuildConfigSpec{
+					CommonSpec: buildv1.CommonSpec{
+						Output: buildv1.BuildOutput{
+							To: &corev1.ObjectReference{
+								Kind: "ImageStreamTag",
+								Name: "output-image:latest",
+							},
+							PushSecret: &corev1.LocalObjectReference{
+								Name: "my-push-secret",
+							},
+						},
+					},
+				},
+			},
+			expectedImage: "image-registry.openshift-image-registry.svc:5000/default/output-image:latest",
+		},
+		{
+			name: "ImageStreamTag output without pushSecret",
+			buildConfig: buildv1.BuildConfig{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-bc",
+					Namespace: "default",
+				},
+				Spec: buildv1.BuildConfigSpec{
+					CommonSpec: buildv1.CommonSpec{
+						Output: buildv1.BuildOutput{
+							To: &corev1.ObjectReference{
+								Kind: "ImageStreamTag",
+								Name: "output-image:latest",
+							},
+							PushSecret: nil,
+						},
+					},
+				},
+			},
+			expectedImage: "image-registry.openshift-image-registry.svc:5000/default/output-image:latest",
+		},
+		{
 			name: "Direct image output",
 			buildConfig: buildv1.BuildConfig{
 				ObjectMeta: metav1.ObjectMeta{
@@ -1759,54 +1803,85 @@ func TestGetServiceAccountFilePath(t *testing.T) {
 func TestProcessDockerStrategyNoCache(t *testing.T) {
 	tests := []struct {
 		name           string
-		noCache        bool
+		buildConfig    buildv1.BuildConfig
 		expectedParams int
+		expectedName   string
 		expectedValue  string
 	}{
 		{
-			name:           "NoCache true adds param",
-			noCache:        true,
+			name: "NoCache true adds param",
+			buildConfig: buildv1.BuildConfig{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-bc",
+					Namespace: "default",
+				},
+				Spec: buildv1.BuildConfigSpec{
+					CommonSpec: buildv1.CommonSpec{
+						Strategy: buildv1.BuildStrategy{
+							Type: buildv1.DockerBuildStrategyType,
+							DockerStrategy: &buildv1.DockerBuildStrategy{
+								NoCache: true,
+							},
+						},
+					},
+				},
+			},
 			expectedParams: 1,
+			expectedName:   NoCacheParamName,
 			expectedValue:  "true",
 		},
 		{
-			name:           "NoCache false adds no param",
-			noCache:        false,
+			name: "NoCache false adds no param",
+			buildConfig: buildv1.BuildConfig{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-bc",
+					Namespace: "default",
+				},
+				Spec: buildv1.BuildConfigSpec{
+					CommonSpec: buildv1.CommonSpec{
+						Strategy: buildv1.BuildStrategy{
+							Type: buildv1.DockerBuildStrategyType,
+							DockerStrategy: &buildv1.DockerBuildStrategy{
+								NoCache: false,
+							},
+						},
+					},
+				},
+			},
 			expectedParams: 0,
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			co := &ConvertOptions{
+				Logger: logrus.New(),
+			}
 			build := &shipwrightv1beta1.Build{
 				Spec: shipwrightv1beta1.BuildSpec{
 					ParamValues: []shipwrightv1beta1.ParamValue{},
 				},
 			}
 
-			if tt.noCache {
-				noCacheValue := "true"
-				noCacheParam := shipwrightv1beta1.ParamValue{
-					Name: "no-cache",
-					SingleValue: &shipwrightv1beta1.SingleValue{
-						Value: &noCacheValue,
-					},
-				}
-				build.Spec.ParamValues = append(build.Spec.ParamValues, noCacheParam)
-			}
+			// Call the actual conversion logic
+			co.processDockerStrategyNoCache(&tt.buildConfig, build)
 
+			// Assertions
 			assert.Equal(t, tt.expectedParams, len(build.Spec.ParamValues))
 
 			if tt.expectedParams > 0 {
 				param := build.Spec.ParamValues[0]
-				assert.Equal(t, "no-cache", param.Name)
-				assert.NotNil(t, param.SingleValue)
-				assert.NotNil(t, param.SingleValue.Value)
-				assert.Equal(t, tt.expectedValue, *param.SingleValue.Value)
+				assert.Equal(t, tt.expectedName, param.Name)
+				if assert.NotNil(t, param.SingleValue) {
+					if assert.NotNil(t, param.SingleValue.Value) {
+						assert.Equal(t, tt.expectedValue, *param.SingleValue.Value)
+					}
+				}
 			}
 		})
 	}
 }
+
 
 // Helper function to create string pointers
 func stringPtr(s string) *string {

--- a/convert/buildconfigs_test.go
+++ b/convert/buildconfigs_test.go
@@ -1756,6 +1756,58 @@ func TestGetServiceAccountFilePath(t *testing.T) {
 	}
 }
 
+func TestProcessDockerStrategyNoCache(t *testing.T) {
+	tests := []struct {
+		name           string
+		noCache        bool
+		expectedParams int
+		expectedValue  string
+	}{
+		{
+			name:           "NoCache true adds param",
+			noCache:        true,
+			expectedParams: 1,
+			expectedValue:  "true",
+		},
+		{
+			name:           "NoCache false adds no param",
+			noCache:        false,
+			expectedParams: 0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			build := &shipwrightv1beta1.Build{
+				Spec: shipwrightv1beta1.BuildSpec{
+					ParamValues: []shipwrightv1beta1.ParamValue{},
+				},
+			}
+
+			if tt.noCache {
+				noCacheValue := "true"
+				noCacheParam := shipwrightv1beta1.ParamValue{
+					Name: "no-cache",
+					SingleValue: &shipwrightv1beta1.SingleValue{
+						Value: &noCacheValue,
+					},
+				}
+				build.Spec.ParamValues = append(build.Spec.ParamValues, noCacheParam)
+			}
+
+			assert.Equal(t, tt.expectedParams, len(build.Spec.ParamValues))
+
+			if tt.expectedParams > 0 {
+				param := build.Spec.ParamValues[0]
+				assert.Equal(t, "no-cache", param.Name)
+				assert.NotNil(t, param.SingleValue)
+				assert.NotNil(t, param.SingleValue.Value)
+				assert.Equal(t, tt.expectedValue, *param.SingleValue.Value)
+			}
+		})
+	}
+}
+
 // Helper function to create string pointers
 func stringPtr(s string) *string {
 	return &s

--- a/convert/rfe.go
+++ b/convert/rfe.go
@@ -1,7 +1,6 @@
 package convert
 
 const (
-	NoCacheFlagRFE           = "https://issues.redhat.com/browse/BUILD-1578"
 	ForcePullFlagRFE         = "https://issues.redhat.com/browse/BUILD-1580"
 	SqashFlagRFE             = "https://issues.redhat.com/browse/BUILD-1581"
 	ConfigMapsRFE            = "https://issues.redhat.com/browse/BUILD-1745"


### PR DESCRIPTION
## Summary
- Map `DockerStrategy.NoCache` from OpenShift BuildConfigs to the Shipwright
  `no-cache` strategy parameter instead of emitting a warning
- Remove the now-implemented `NoCacheFlagRFE` constant from `rfe.go`
- Add unit tests for the new `processDockerStrategyNoCache` conversion method

## Context
Resolves [BUILD-1578](https://issues.redhat.com/browse/BUILD-1578). When a
BuildConfig has `NoCache: true`, crane-lib previously warned that this flag
was unsupported. With the corresponding `no-cache` parameter added to the
downstream Buildah ClusterBuildStrategy (operator repo), crane-lib now maps
the field to `paramValues: [{name: "no-cache", value: "true"}]` on the
generated Shipwright Build.

## Changes
- `convert/buildconfigs.go`: Replace inline warning with
  `processDockerStrategyNoCache()` method that adds the `no-cache` param
  when `NoCache` is true
- `convert/buildconfigs_test.go`: Add `TestProcessDockerStrategyNoCache`
  (true/false cases) and additional ImageStreamTag output test cases
- `convert/rfe.go`: Remove `NoCacheFlagRFE` constant

## Test plan
- [x] Unit tests: 72/72 pass (`GOWORK=off go test ./convert/... -v`)
- [x] Cluster test on OpenShift 4.20.0-nightly: `no-cache` param accepted
  by strategy, BuildRun completed successfully

## Companion PR
- Operator repo: `no-cache` parameter added to `buildah.yaml` strategy
  (branch `BUILD-1578-no-cache-buildah` on `redhat-openshift-builds/operator`)

Co-authored-by: Claude Code

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Build conversions now preserve the Docker “no cache” setting as a build parameter, enabling cache-bypassing behavior in generated builds.

* **Bug Fixes**
  * Improved output handling so image references stay consistent whether a push secret is provided or not.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->