### PR TITLE
[BUILD-1746] feat: map DockerStrategy.From to runtime-stage-from param

### DIFF
--- a/convert/buildconfigs.go
+++ b/convert/buildconfigs.go
@@ -39,8 +39,9 @@ const (
 	GitHTTPSProxy = "HTTPS_PROXY"
 	GitNoProxy    = "NO_PROXY"
 
-	// Docker Strategy Parameters
-	NoCacheParamName = "no-cache"
+	// Buildah Strategy Param Names
+	NoCacheParamName          = "no-cache"
+	RuntimeStageFromParamName = "runtime-stage-from"
 
 	Timeout = 10 * time.Minute
 )
@@ -322,25 +323,13 @@ func (t *ConvertOptions) processDockerStrategyFromField(bc *buildv1.BuildConfig,
 	}
 
 	switch fromKind := from.Kind; fromKind {
-	case ImageStreamTag:
+	case ImageStreamTag, ImageStreamImage:
 		imageRef, err := t.resolveImageStreamRef(from.Name, from.Namespace)
 		if err != nil {
 			return err
 		}
 		paramValue := shipwrightv1beta1.ParamValue{
-			Name: "runtime-stage-from",
-			SingleValue: &shipwrightv1beta1.SingleValue{
-				Value: &imageRef,
-			},
-		}
-		b.Spec.ParamValues = append(b.Spec.ParamValues, paramValue)
-	case ImageStreamImage:
-		imageRef, err := t.resolveImageStreamRef(from.Name, from.Namespace)
-		if err != nil {
-			return err
-		}
-		paramValue := shipwrightv1beta1.ParamValue{
-			Name: "runtime-stage-from",
+			Name: RuntimeStageFromParamName,
 			SingleValue: &shipwrightv1beta1.SingleValue{
 				Value: &imageRef,
 			},
@@ -348,7 +337,7 @@ func (t *ConvertOptions) processDockerStrategyFromField(bc *buildv1.BuildConfig,
 		b.Spec.ParamValues = append(b.Spec.ParamValues, paramValue)
 	case DockerImage:
 		paramValue := shipwrightv1beta1.ParamValue{
-			Name: "runtime-stage-from",
+			Name: RuntimeStageFromParamName,
 			SingleValue: &shipwrightv1beta1.SingleValue{
 				Value: &from.Name,
 			},
@@ -358,7 +347,7 @@ func (t *ConvertOptions) processDockerStrategyFromField(bc *buildv1.BuildConfig,
 		return fmt.Errorf("docker strategy 'From' kind %s is unknown for BuildConfig %s", fromKind, bc.Name)
 	}
 
-	t.Logger.Infof("Docker strategy From field mapped to runtime-stage-from param for BuildConfig %s", bc.Name)
+	t.Logger.Infof("Docker strategy From field mapped to %s param for BuildConfig %s", RuntimeStageFromParamName, bc.Name)
 	return nil
 }
 

--- a/convert/buildconfigs.go
+++ b/convert/buildconfigs.go
@@ -277,7 +277,7 @@ func (t *ConvertOptions) processStrategyFromField(bc *buildv1.BuildConfig, b *sh
 		}
 		b.Spec.ParamValues = append(b.Spec.ParamValues, paramValue)
 	case ImageStreamImage:
-		imageRef, err := t.resolveImageStreamRef(from.Name, from.Namespace)
+		imageRef, err := t.resolveImageStreamImageRef(from.Name, from.Namespace)
 		if err != nil {
 			return err
 		}
@@ -323,8 +323,20 @@ func (t *ConvertOptions) processDockerStrategyFromField(bc *buildv1.BuildConfig,
 	}
 
 	switch fromKind := from.Kind; fromKind {
-	case ImageStreamTag, ImageStreamImage:
+	case ImageStreamTag:
 		imageRef, err := t.resolveImageStreamRef(from.Name, from.Namespace)
+		if err != nil {
+			return err
+		}
+		paramValue := shipwrightv1beta1.ParamValue{
+			Name: RuntimeStageFromParamName,
+			SingleValue: &shipwrightv1beta1.SingleValue{
+				Value: &imageRef,
+			},
+		}
+		b.Spec.ParamValues = append(b.Spec.ParamValues, paramValue)
+	case ImageStreamImage:
+		imageRef, err := t.resolveImageStreamImageRef(from.Name, from.Namespace)
 		if err != nil {
 			return err
 		}
@@ -738,7 +750,7 @@ func (t *ConvertOptions) processBuildSourceFromField(bc *buildv1.BuildConfig, b 
 			},
 		}
 	case ImageStreamImage:
-		imageRef, err := t.resolveImageStreamRef(fromImage.Name, fromImage.Namespace)
+		imageRef, err := t.resolveImageStreamImageRef(fromImage.Name, fromImage.Namespace)
 		if err != nil {
 			return fmt.Errorf("failed to resolve image stream image: %v", err)
 		}
@@ -837,6 +849,20 @@ func (t *ConvertOptions) resolveImageStreamRef(name string, namespace string) (s
 	imageRef := imageStreamTag.Tag.From.Name
 
 	return imageRef, nil
+}
+
+func (t *ConvertOptions) resolveImageStreamImageRef(name string, namespace string) (string, error) {
+	imageStreamImage := imagev1.ImageStreamImage{}
+
+	err := t.Client.Get(context.Background(), client.ObjectKey{
+		Namespace: namespace,
+		Name:      name,
+	}, &imageStreamImage)
+	if err != nil {
+		return "", err
+	}
+
+	return imageStreamImage.Image.DockerImageReference, nil
 }
 
 func (t *ConvertOptions) writeBuildConfigs(bcList buildv1.BuildConfigList) error {

--- a/convert/buildconfigs.go
+++ b/convert/buildconfigs.go
@@ -91,7 +91,10 @@ func (t *ConvertOptions) convertBuildConfigs() error {
 
 			// process From field
 			if bc.Spec.Strategy.DockerStrategy.From != nil {
-				t.Logger.Warnf("From Field in BuildConfig's Docker strategy is not yet supported in built-in Buildah ClusterBuildStrategy in Shipwright. RFE: %s", RuntimeStageFromRFE)
+				if err := t.processDockerStrategyFromField(&bc, b); err != nil {
+					t.Logger.Errorf("Error processing From field for Docker strategy: %v", err)
+					return err
+				}
 			}
 
 			// process PullSecret field
@@ -296,6 +299,66 @@ func (t *ConvertOptions) processStrategyFromField(bc *buildv1.BuildConfig, b *sh
 	default:
 		return fmt.Errorf("strategy 'From' kind %s is unknown type %s for BuildConfig %s", fromKind, bc.Spec.Strategy.Type, bc.Name)
 	}
+	return nil
+}
+
+// processDockerStrategyFromField processes the From field for Docker strategy
+func (t *ConvertOptions) processDockerStrategyFromField(bc *buildv1.BuildConfig, b *shipwrightv1beta1.Build) error {
+	from := bc.Spec.Strategy.DockerStrategy.From
+	if from == nil {
+		return nil
+	}
+
+	if from.Kind == "" || from.Name == "" {
+		return nil
+	}
+
+	if from.Namespace == "" {
+		from.Namespace = bc.Namespace
+	}
+
+	if b.Spec.ParamValues == nil {
+		b.Spec.ParamValues = []shipwrightv1beta1.ParamValue{}
+	}
+
+	switch fromKind := from.Kind; fromKind {
+	case ImageStreamTag:
+		imageRef, err := t.resolveImageStreamRef(from.Name, from.Namespace)
+		if err != nil {
+			return err
+		}
+		paramValue := shipwrightv1beta1.ParamValue{
+			Name: "runtime-stage-from",
+			SingleValue: &shipwrightv1beta1.SingleValue{
+				Value: &imageRef,
+			},
+		}
+		b.Spec.ParamValues = append(b.Spec.ParamValues, paramValue)
+	case ImageStreamImage:
+		imageRef, err := t.resolveImageStreamRef(from.Name, from.Namespace)
+		if err != nil {
+			return err
+		}
+		paramValue := shipwrightv1beta1.ParamValue{
+			Name: "runtime-stage-from",
+			SingleValue: &shipwrightv1beta1.SingleValue{
+				Value: &imageRef,
+			},
+		}
+		b.Spec.ParamValues = append(b.Spec.ParamValues, paramValue)
+	case DockerImage:
+		paramValue := shipwrightv1beta1.ParamValue{
+			Name: "runtime-stage-from",
+			SingleValue: &shipwrightv1beta1.SingleValue{
+				Value: &from.Name,
+			},
+		}
+		b.Spec.ParamValues = append(b.Spec.ParamValues, paramValue)
+	default:
+		return fmt.Errorf("docker strategy 'From' kind %s is unknown for BuildConfig %s", fromKind, bc.Name)
+	}
+
+	t.Logger.Infof("Docker strategy From field mapped to runtime-stage-from param for BuildConfig %s", bc.Name)
 	return nil
 }
 

--- a/convert/buildconfigs.go
+++ b/convert/buildconfigs.go
@@ -232,11 +232,8 @@ func (t *ConvertOptions) convertBuildConfigs() error {
 
 // processStrategyFromField processes From field for Source-to-Image strategy
 func (t *ConvertOptions) processStrategyFromField(bc *buildv1.BuildConfig, b *shipwrightv1beta1.Build) error {
-	// Extract From field from whichever strategy is present
 	var from *corev1.ObjectReference
-	if bc.Spec.Strategy.DockerStrategy != nil && bc.Spec.Strategy.DockerStrategy.From != nil {
-		from = bc.Spec.Strategy.DockerStrategy.From
-	} else if bc.Spec.Strategy.SourceStrategy != nil && bc.Spec.Strategy.SourceStrategy.From.Name != "" {
+	if bc.Spec.Strategy.SourceStrategy != nil && bc.Spec.Strategy.SourceStrategy.From.Name != "" {
 		from = &bc.Spec.Strategy.SourceStrategy.From
 	} else {
 		t.Logger.Debugf("No From field to process for BuildConfig %s", bc.Name)
@@ -322,42 +319,31 @@ func (t *ConvertOptions) processDockerStrategyFromField(bc *buildv1.BuildConfig,
 		b.Spec.ParamValues = []shipwrightv1beta1.ParamValue{}
 	}
 
+	var imageRef string
+	var err error
+
 	switch fromKind := from.Kind; fromKind {
 	case ImageStreamTag:
-		imageRef, err := t.resolveImageStreamRef(from.Name, from.Namespace)
-		if err != nil {
-			return err
-		}
-		paramValue := shipwrightv1beta1.ParamValue{
-			Name: RuntimeStageFromParamName,
-			SingleValue: &shipwrightv1beta1.SingleValue{
-				Value: &imageRef,
-			},
-		}
-		b.Spec.ParamValues = append(b.Spec.ParamValues, paramValue)
+		imageRef, err = t.resolveImageStreamRef(from.Name, from.Namespace)
 	case ImageStreamImage:
-		imageRef, err := t.resolveImageStreamImageRef(from.Name, from.Namespace)
-		if err != nil {
-			return err
-		}
-		paramValue := shipwrightv1beta1.ParamValue{
-			Name: RuntimeStageFromParamName,
-			SingleValue: &shipwrightv1beta1.SingleValue{
-				Value: &imageRef,
-			},
-		}
-		b.Spec.ParamValues = append(b.Spec.ParamValues, paramValue)
+		imageRef, err = t.resolveImageStreamImageRef(from.Name, from.Namespace)
 	case DockerImage:
-		paramValue := shipwrightv1beta1.ParamValue{
-			Name: RuntimeStageFromParamName,
-			SingleValue: &shipwrightv1beta1.SingleValue{
-				Value: &from.Name,
-			},
-		}
-		b.Spec.ParamValues = append(b.Spec.ParamValues, paramValue)
+		imageRef = from.Name
 	default:
 		return fmt.Errorf("docker strategy 'From' kind %s is unknown for BuildConfig %s", fromKind, bc.Name)
 	}
+
+	if err != nil {
+		return err
+	}
+
+	paramValue := shipwrightv1beta1.ParamValue{
+		Name: RuntimeStageFromParamName,
+		SingleValue: &shipwrightv1beta1.SingleValue{
+			Value: &imageRef,
+		},
+	}
+	b.Spec.ParamValues = append(b.Spec.ParamValues, paramValue)
 
 	t.Logger.Infof("Docker strategy From field mapped to %s param for BuildConfig %s", RuntimeStageFromParamName, bc.Name)
 	return nil

--- a/convert/buildconfigs_test.go
+++ b/convert/buildconfigs_test.go
@@ -41,6 +41,13 @@ func (m *MockClient) Get(ctx context.Context, key client.ObjectKey, obj client.O
 			},
 		}
 	}
+
+	// Handle ImageStreamImage mock response
+	if isi, ok := obj.(*imagev1.ImageStreamImage); ok {
+		isi.Image = imagev1.Image{
+			DockerImageReference: "registry.example.com/image@sha256:deadbeef",
+		}
+	}
 	return nil
 }
 
@@ -653,7 +660,7 @@ func TestProcessDockerStrategyFromField(t *testing.T) {
 			Logger: logrus.New(),
 		}
 
-		// Mock Get to succeed and populate ImageStreamTag (resolveImageStreamRef uses ImageStreamTag)
+		// Mock Get to succeed and populate ImageStreamImage
 		mockClient.On("Get", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil)
 
 		bc := &buildv1.BuildConfig{
@@ -677,7 +684,7 @@ func TestProcessDockerStrategyFromField(t *testing.T) {
 		assert.Equal(t, RuntimeStageFromParamName, build.Spec.ParamValues[0].Name)
 		if assert.NotNil(t, build.Spec.ParamValues[0].SingleValue) {
 			if assert.NotNil(t, build.Spec.ParamValues[0].SingleValue.Value) {
-				assert.Equal(t, "registry.example.com/image:latest", *build.Spec.ParamValues[0].SingleValue.Value)
+				assert.Equal(t, "registry.example.com/image@sha256:deadbeef", *build.Spec.ParamValues[0].SingleValue.Value)
 			}
 		}
 
@@ -810,7 +817,7 @@ func TestProcessSourceStrategyFromField(t *testing.T) {
 			Logger: logrus.New(),
 		}
 
-		// Mock Get to succeed and populate ImageStreamTag (resolveImageStreamRef uses ImageStreamTag)
+		// Mock Get to succeed and populate ImageStreamImage
 		mockClient.On("Get", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil)
 
 		bc := &buildv1.BuildConfig{
@@ -836,7 +843,7 @@ func TestProcessSourceStrategyFromField(t *testing.T) {
 		assert.Equal(t, "builder-image", build.Spec.ParamValues[0].Name)
 		if assert.NotNil(t, build.Spec.ParamValues[0].SingleValue) {
 			if assert.NotNil(t, build.Spec.ParamValues[0].SingleValue.Value) {
-				assert.Equal(t, "registry.example.com/image:latest", *build.Spec.ParamValues[0].SingleValue.Value)
+				assert.Equal(t, "registry.example.com/image@sha256:deadbeef", *build.Spec.ParamValues[0].SingleValue.Value)
 			}
 		}
 

--- a/convert/buildconfigs_test.go
+++ b/convert/buildconfigs_test.go
@@ -636,7 +636,7 @@ func TestProcessDockerStrategyFromField(t *testing.T) {
 		err := co.processDockerStrategyFromField(bc, build)
 		assert.NoError(t, err)
 		assert.Len(t, build.Spec.ParamValues, 1)
-		assert.Equal(t, "runtime-stage-from", build.Spec.ParamValues[0].Name)
+		assert.Equal(t, RuntimeStageFromParamName, build.Spec.ParamValues[0].Name)
 		if assert.NotNil(t, build.Spec.ParamValues[0].SingleValue) {
 			if assert.NotNil(t, build.Spec.ParamValues[0].SingleValue.Value) {
 				assert.Equal(t, "registry.example.com/image:latest", *build.Spec.ParamValues[0].SingleValue.Value)
@@ -674,7 +674,7 @@ func TestProcessDockerStrategyFromField(t *testing.T) {
 		err := co.processDockerStrategyFromField(bc, build)
 		assert.NoError(t, err)
 		assert.Len(t, build.Spec.ParamValues, 1)
-		assert.Equal(t, "runtime-stage-from", build.Spec.ParamValues[0].Name)
+		assert.Equal(t, RuntimeStageFromParamName, build.Spec.ParamValues[0].Name)
 		if assert.NotNil(t, build.Spec.ParamValues[0].SingleValue) {
 			if assert.NotNil(t, build.Spec.ParamValues[0].SingleValue.Value) {
 				assert.Equal(t, "registry.example.com/image:latest", *build.Spec.ParamValues[0].SingleValue.Value)
@@ -707,7 +707,7 @@ func TestProcessDockerStrategyFromField(t *testing.T) {
 		err := co.processDockerStrategyFromField(bc, build)
 		assert.NoError(t, err)
 		assert.Len(t, build.Spec.ParamValues, 1)
-		assert.Equal(t, "runtime-stage-from", build.Spec.ParamValues[0].Name)
+		assert.Equal(t, RuntimeStageFromParamName, build.Spec.ParamValues[0].Name)
 		if assert.NotNil(t, build.Spec.ParamValues[0].SingleValue) {
 			if assert.NotNil(t, build.Spec.ParamValues[0].SingleValue.Value) {
 				assert.Equal(t, "docker.io/library/nginx:latest", *build.Spec.ParamValues[0].SingleValue.Value)

--- a/convert/buildconfigs_test.go
+++ b/convert/buildconfigs_test.go
@@ -633,11 +633,10 @@ func TestProcessDockerStrategyFromField(t *testing.T) {
 
 		build := &shipwrightv1beta1.Build{Spec: shipwrightv1beta1.BuildSpec{}}
 
-		err := co.processStrategyFromField(bc, build)
+		err := co.processDockerStrategyFromField(bc, build)
 		assert.NoError(t, err)
-		assert.Nil(t, build.Spec.Source)
 		assert.Len(t, build.Spec.ParamValues, 1)
-		assert.Equal(t, "builder-image", build.Spec.ParamValues[0].Name)
+		assert.Equal(t, "runtime-stage-from", build.Spec.ParamValues[0].Name)
 		if assert.NotNil(t, build.Spec.ParamValues[0].SingleValue) {
 			if assert.NotNil(t, build.Spec.ParamValues[0].SingleValue.Value) {
 				assert.Equal(t, "registry.example.com/image:latest", *build.Spec.ParamValues[0].SingleValue.Value)
@@ -672,11 +671,10 @@ func TestProcessDockerStrategyFromField(t *testing.T) {
 
 		build := &shipwrightv1beta1.Build{Spec: shipwrightv1beta1.BuildSpec{}}
 
-		err := co.processStrategyFromField(bc, build)
+		err := co.processDockerStrategyFromField(bc, build)
 		assert.NoError(t, err)
-		assert.Nil(t, build.Spec.Source)
 		assert.Len(t, build.Spec.ParamValues, 1)
-		assert.Equal(t, "builder-image", build.Spec.ParamValues[0].Name)
+		assert.Equal(t, "runtime-stage-from", build.Spec.ParamValues[0].Name)
 		if assert.NotNil(t, build.Spec.ParamValues[0].SingleValue) {
 			if assert.NotNil(t, build.Spec.ParamValues[0].SingleValue.Value) {
 				assert.Equal(t, "registry.example.com/image:latest", *build.Spec.ParamValues[0].SingleValue.Value)
@@ -706,11 +704,10 @@ func TestProcessDockerStrategyFromField(t *testing.T) {
 
 		build := &shipwrightv1beta1.Build{Spec: shipwrightv1beta1.BuildSpec{}}
 
-		err := co.processStrategyFromField(bc, build)
+		err := co.processDockerStrategyFromField(bc, build)
 		assert.NoError(t, err)
-		assert.Nil(t, build.Spec.Source)
 		assert.Len(t, build.Spec.ParamValues, 1)
-		assert.Equal(t, "builder-image", build.Spec.ParamValues[0].Name)
+		assert.Equal(t, "runtime-stage-from", build.Spec.ParamValues[0].Name)
 		if assert.NotNil(t, build.Spec.ParamValues[0].SingleValue) {
 			if assert.NotNil(t, build.Spec.ParamValues[0].SingleValue.Value) {
 				assert.Equal(t, "docker.io/library/nginx:latest", *build.Spec.ParamValues[0].SingleValue.Value)
@@ -738,9 +735,8 @@ func TestProcessDockerStrategyFromField(t *testing.T) {
 
 		build := &shipwrightv1beta1.Build{Spec: shipwrightv1beta1.BuildSpec{}}
 
-		err := co.processStrategyFromField(bc, build)
+		err := co.processDockerStrategyFromField(bc, build)
 		assert.Error(t, err)
-		assert.Nil(t, build.Spec.Source)
 		assert.Empty(t, build.Spec.ParamValues)
 	})
 
@@ -760,9 +756,8 @@ func TestProcessDockerStrategyFromField(t *testing.T) {
 
 		build := &shipwrightv1beta1.Build{Spec: shipwrightv1beta1.BuildSpec{}}
 
-		err := co.processStrategyFromField(bc, build)
+		err := co.processDockerStrategyFromField(bc, build)
 		assert.NoError(t, err)
-		assert.Nil(t, build.Spec.Source)
 		assert.Empty(t, build.Spec.ParamValues)
 	})
 }

--- a/convert/rfe.go
+++ b/convert/rfe.go
@@ -5,7 +5,6 @@ const (
 	SqashFlagRFE             = "https://issues.redhat.com/browse/BUILD-1581"
 	ConfigMapsRFE            = "https://issues.redhat.com/browse/BUILD-1745"
 	SecretsRFE               = "https://issues.redhat.com/browse/BUILD-1744"
-	RuntimeStageFromRFE      = "https://issues.redhat.com/browse/BUILD-1746"
 	DockerStrategyVolumesRFE = "https://issues.redhat.com/browse/BUILD-1747"
 	CustomScriptsRFE         = "https://issues.redhat.com/browse/BUILD-1641"
 	IncrementalBuildRFE      = "https://issues.redhat.com/browse/BUILD-1607"


### PR DESCRIPTION
## Summary
- Maps BuildConfig's `Spec.Strategy.DockerStrategy.From` field to Shipwright Build's `runtime-stage-from` param
- Handles all three `From.Kind` types: DockerImage (literal), ImageStreamTag (resolved), ImageStreamImage (resolved via dedicated API)
- Removes the `RuntimeStageFromRFE` warning constant — the feature is now implemented

## Changes
- `processDockerStrategyFromField()` — new function that resolves the From reference and sets the `runtime-stage-from` param value
- `resolveImageStreamImageRef()` — new function for resolving `ImageStreamImage` references (separate from the existing `resolveImageStreamRef` which handles `ImageStreamTag`)
- Split `ImageStreamImage` case in `processStrategyFromField` and `processCustomBuildSourceImages` to use the correct resolver
- Removed `RuntimeStageFromRFE` constant from `rfe.go`

## Test plan
- [x] Unit tests: 67/67 PASS
- [x] Cluster test: DockerImage kind → param set with literal name (6.9MB image)
- [x] Cluster test: ImageStreamTag kind → param resolved from IS (6.9MB image)
- [x] Cluster test: No From field → no param added, no error (38.8MB image)
- [x] Cluster test: True multi-stage Dockerfile → only last FROM replaced
- [x] Full e2e: BuildConfig → crane convert → Shipwright Build → BuildRun — PASS

## Dependencies
- Requires operator PR: https://github.com/redhat-openshift-builds/operator/pull/1383 (adds `runtime-stage-from` param to buildah strategy)
- Operator PR must merge first, otherwise the param is silently ignored

## Related
- Jira: https://issues.redhat.com/browse/BUILD-1746

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Docker-based builds now support specifying the source image used for runtime stages.
  * ImageStream images are resolved using their canonical digest-based references for more accurate build configuration.

* **Bug Fixes**
  * Improved conversion of Docker strategy and source image references.
  * Replaced unsupported handling with successful validation and conversion of Docker source images.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->