### PR TITLE
[BUILD-1756] feat: support pushing output images to OpenShift imagestreams

### DIFF
--- a/convert/buildconfigs.go
+++ b/convert/buildconfigs.go
@@ -719,7 +719,10 @@ func (t *ConvertOptions) processOutput(bc buildv1.BuildConfig, b *shipwrightv1be
 			namespace = bc.Namespace
 		}
 		b.Spec.Output.Image = "image-registry.openshift-image-registry.svc:5000/" + namespace + "/" + bc.Spec.Output.To.Name
-		t.Logger.Warnf("Push to Openshift ImageStreams is not yet supported in Shipwright. RFE: %s", ImageStreamsPushRFE)
+		t.Logger.Infof("ImageStreamTag output converted to internal registry URL: %s", b.Spec.Output.Image)
+		if bc.Spec.Output.PushSecret == nil || bc.Spec.Output.PushSecret.Name == "" {
+			t.Logger.Infof("No explicit pushSecret found for ImageStreamTag output. Ensure the BuildRun uses a ServiceAccount with internal registry push access (e.g., 'pipeline' SA managed by OpenShift Pipelines).")
+		}
 	} else {
 		b.Spec.Output.Image = bc.Spec.Output.To.Name
 	}

--- a/convert/buildconfigs.go
+++ b/convert/buildconfigs.go
@@ -721,7 +721,7 @@ func (t *ConvertOptions) processOutput(bc buildv1.BuildConfig, b *shipwrightv1be
 		b.Spec.Output.Image = "image-registry.openshift-image-registry.svc:5000/" + namespace + "/" + bc.Spec.Output.To.Name
 		t.Logger.Infof("ImageStreamTag output converted to internal registry URL: %s", b.Spec.Output.Image)
 		if bc.Spec.Output.PushSecret == nil || bc.Spec.Output.PushSecret.Name == "" {
-			t.Logger.Infof("No explicit pushSecret found for ImageStreamTag output. Ensure the BuildRun uses a ServiceAccount with internal registry push access (e.g., 'pipeline' SA managed by OpenShift Pipelines).")
+			t.Logger.Warnf("No explicit pushSecret found for ImageStreamTag output. Ensure the BuildRun uses a ServiceAccount with internal registry push access (e.g., 'pipeline' SA managed by OpenShift Pipelines).")
 		}
 	} else {
 		b.Spec.Output.Image = bc.Spec.Output.To.Name

--- a/convert/buildconfigs.go
+++ b/convert/buildconfigs.go
@@ -718,7 +718,11 @@ func (t *ConvertOptions) processOutput(bc buildv1.BuildConfig, b *shipwrightv1be
 		} else {
 			namespace = bc.Namespace
 		}
-		b.Spec.Output.Image = "image-registry.openshift-image-registry.svc:5000/" + namespace + "/" + bc.Spec.Output.To.Name
+		name := bc.Spec.Output.To.Name
+		if !strings.Contains(name, ":") {
+			name = name + ":latest"
+		}
+		b.Spec.Output.Image = "image-registry.openshift-image-registry.svc:5000/" + namespace + "/" + name
 		t.Logger.Infof("ImageStreamTag output converted to internal registry URL: %s", b.Spec.Output.Image)
 		if bc.Spec.Output.PushSecret == nil || bc.Spec.Output.PushSecret.Name == "" {
 			t.Logger.Warnf("No explicit pushSecret found for ImageStreamTag output. Ensure the BuildRun uses a ServiceAccount with internal registry push access (e.g., 'pipeline' SA managed by OpenShift Pipelines).")

--- a/convert/buildconfigs_test.go
+++ b/convert/buildconfigs_test.go
@@ -367,6 +367,49 @@ func TestProcessOutput(t *testing.T) {
 			},
 			expectedImage: "registry.example.com/image:tag",
 		},
+		{
+			name: "ImageStreamTag output without pushSecret",
+			buildConfig: buildv1.BuildConfig{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-bc",
+					Namespace: "test-ns",
+				},
+				Spec: buildv1.BuildConfigSpec{
+					CommonSpec: buildv1.CommonSpec{
+						Output: buildv1.BuildOutput{
+							To: &corev1.ObjectReference{
+								Kind: "ImageStreamTag",
+								Name: "myimage:latest",
+							},
+						},
+					},
+				},
+			},
+			expectedImage: "image-registry.openshift-image-registry.svc:5000/test-ns/myimage:latest",
+		},
+		{
+			name: "ImageStreamTag output with pushSecret",
+			buildConfig: buildv1.BuildConfig{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-bc",
+					Namespace: "test-ns",
+				},
+				Spec: buildv1.BuildConfigSpec{
+					CommonSpec: buildv1.CommonSpec{
+						Output: buildv1.BuildOutput{
+							To: &corev1.ObjectReference{
+								Kind: "ImageStreamTag",
+								Name: "myimage:latest",
+							},
+							PushSecret: &corev1.LocalObjectReference{
+								Name: "my-push-secret",
+							},
+						},
+					},
+				},
+			},
+			expectedImage: "image-registry.openshift-image-registry.svc:5000/test-ns/myimage:latest",
+		},
 	}
 
 	for _, tt := range tests {

--- a/convert/buildconfigs_test.go
+++ b/convert/buildconfigs_test.go
@@ -368,7 +368,7 @@ func TestProcessOutput(t *testing.T) {
 			expectedImage: "registry.example.com/image:tag",
 		},
 		{
-			name: "ImageStreamTag output without pushSecret",
+			name: "ImageStreamTag output without pushSecret - custom namespace",
 			buildConfig: buildv1.BuildConfig{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "test-bc",
@@ -403,6 +403,47 @@ func TestProcessOutput(t *testing.T) {
 							},
 							PushSecret: &corev1.LocalObjectReference{
 								Name: "my-push-secret",
+							},
+						},
+					},
+				},
+			},
+			expectedImage: "image-registry.openshift-image-registry.svc:5000/test-ns/myimage:latest",
+		},
+		{
+			name: "ImageStreamTag output with cross-namespace reference",
+			buildConfig: buildv1.BuildConfig{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-bc",
+					Namespace: "test-ns",
+				},
+				Spec: buildv1.BuildConfigSpec{
+					CommonSpec: buildv1.CommonSpec{
+						Output: buildv1.BuildOutput{
+							To: &corev1.ObjectReference{
+								Kind:      "ImageStreamTag",
+								Name:      "myimage:v1",
+								Namespace: "other-ns",
+							},
+						},
+					},
+				},
+			},
+			expectedImage: "image-registry.openshift-image-registry.svc:5000/other-ns/myimage:v1",
+		},
+		{
+			name: "ImageStreamTag output without tag defaults to latest",
+			buildConfig: buildv1.BuildConfig{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-bc",
+					Namespace: "test-ns",
+				},
+				Spec: buildv1.BuildConfigSpec{
+					CommonSpec: buildv1.CommonSpec{
+						Output: buildv1.BuildOutput{
+							To: &corev1.ObjectReference{
+								Kind: "ImageStreamTag",
+								Name: "myimage",
 							},
 						},
 					},

--- a/convert/rfe.go
+++ b/convert/rfe.go
@@ -11,5 +11,4 @@ const (
 	IncrementalBuildRFE      = "https://issues.redhat.com/browse/BUILD-1607"
 	ForcePullFlagS2iRFE      = "https://issues.redhat.com/browse/BUILD-1606"
 	PullSecretS2IRFE         = "https://issues.redhat.com/browse/BUILD-1749"
-	ImageStreamsPushRFE      = "https://issues.redhat.com/browse/BUILD-1756"
 )


### PR DESCRIPTION
## Summary
- Convert ImageStreamTag output to internal registry URL (`image-registry.openshift-image-registry.svc:5000/<namespace>/<name>:<tag>`) instead of warning "not supported"
- Emit info log with the converted URL for visibility
- Warn when no explicit pushSecret is set (user needs a ServiceAccount with registry push access)
- Default to `:latest` tag when ImageStreamTag name has no colon (matches OpenShift behavior)
- Remove the `ImageStreamsPushRFE` constant from `rfe.go` (feature now implemented)

## Test plan
- [x] Unit tests: 76/76 PASS (includes new test cases for cross-namespace, tagless, with/without pushSecret)
- [x] Cluster test: BuildConfig (IST output) → crane convert → Shipwright Build → BuildRun push → PASS
- [x] Image pull verification: Pod pulled image from internal registry, content matched expected output
- [x] Cluster: OpenShift 4.20.0-0.nightly-2026-07-15-212908

## Related
- Jira: https://issues.redhat.com/browse/BUILD-1756

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * ImageStreamTag outputs now default to the `latest` tag when no tag is provided.
  * ImageStreamTag references support custom and cross-namespace targets.
  * Informational messages clarify image conversion behavior.

* **Bug Fixes**
  * Added a warning when no push secret is configured for ImageStreamTag outputs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->