### PR TITLE
[BUILD-1580] feat: map DockerStrategy ForcePull to buildah pull parameter

### DIFF
--- a/convert/buildconfigs.go
+++ b/convert/buildconfigs.go
@@ -42,6 +42,7 @@ const (
 	// Buildah Strategy Param Names
 	NoCacheParamName          = "no-cache"
 	SquashParamName           = "squash"
+	ForcePullParamName        = "pull"
 	RuntimeStageFromParamName = "runtime-stage-from"
 
 	Timeout = 10 * time.Minute
@@ -127,9 +128,7 @@ func (t *ConvertOptions) convertBuildConfigs() error {
 			}
 
 			// process force pull field
-			if bc.Spec.Strategy.DockerStrategy.ForcePull {
-				t.Logger.Warnf("ForcePull flag is not yet supported in the built-in Buildah ClusterBuildStrategy in Shipwright. RFE: %s", ForcePullFlagRFE)
-			}
+			t.processDockerStrategyForcePull(&bc, b)
 
 			// process docker file path
 			if bc.Spec.Strategy.DockerStrategy.DockerfilePath != "" {
@@ -1004,6 +1003,20 @@ func (t *ConvertOptions) processDockerStrategySquash(bc *buildv1.BuildConfig, b 
 		t.Logger.Infof("ImageOptimizationPolicy is None for BuildConfig %s, no squash param needed", bc.Name)
 	default:
 		t.Logger.Warnf("Unknown ImageOptimizationPolicy %q for BuildConfig %s", policy, bc.Name)
+	}
+}
+
+func (t *ConvertOptions) processDockerStrategyForcePull(bc *buildv1.BuildConfig, b *shipwrightv1beta1.Build) {
+	if bc.Spec.Strategy.DockerStrategy.ForcePull {
+		t.Logger.Infof("Mapping ForcePull flag to pull param for BuildConfig %s", bc.Name)
+		pullValue := "always"
+		pullParam := shipwrightv1beta1.ParamValue{
+			Name: ForcePullParamName,
+			SingleValue: &shipwrightv1beta1.SingleValue{
+				Value: &pullValue,
+			},
+		}
+		b.Spec.ParamValues = append(b.Spec.ParamValues, pullParam)
 	}
 }
 

--- a/convert/buildconfigs_test.go
+++ b/convert/buildconfigs_test.go
@@ -1842,6 +1842,73 @@ func TestProcessDockerStrategyEnv(t *testing.T) {
 	}
 }
 
+func TestProcessDockerStrategyForcePull(t *testing.T) {
+	tests := []struct {
+		name           string
+		buildConfig    *buildv1.BuildConfig
+		expectedParams int
+		expectedName   string
+		expectedValue  string
+	}{
+		{
+			name: "ForcePull true - maps to pull=always",
+			buildConfig: &buildv1.BuildConfig{
+				ObjectMeta: metav1.ObjectMeta{Name: "test-bc"},
+				Spec: buildv1.BuildConfigSpec{
+					CommonSpec: buildv1.CommonSpec{
+						Strategy: buildv1.BuildStrategy{
+							Type: buildv1.DockerBuildStrategyType,
+							DockerStrategy: &buildv1.DockerBuildStrategy{
+								ForcePull: true,
+							},
+						},
+					},
+				},
+			},
+			expectedParams: 1,
+			expectedName:   "pull",
+			expectedValue:  "always",
+		},
+		{
+			name: "ForcePull false - no param added",
+			buildConfig: &buildv1.BuildConfig{
+				ObjectMeta: metav1.ObjectMeta{Name: "test-bc"},
+				Spec: buildv1.BuildConfigSpec{
+					CommonSpec: buildv1.CommonSpec{
+						Strategy: buildv1.BuildStrategy{
+							Type: buildv1.DockerBuildStrategyType,
+							DockerStrategy: &buildv1.DockerBuildStrategy{
+								ForcePull: false,
+							},
+						},
+					},
+				},
+			},
+			expectedParams: 0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			co := &ConvertOptions{
+				Logger: logrus.New(),
+			}
+			build := &shipwrightv1beta1.Build{
+				Spec: shipwrightv1beta1.BuildSpec{},
+			}
+
+			co.processDockerStrategyForcePull(tt.buildConfig, build)
+
+			assert.Equal(t, tt.expectedParams, len(build.Spec.ParamValues))
+
+			if tt.expectedParams > 0 {
+				assert.Equal(t, tt.expectedName, build.Spec.ParamValues[0].Name)
+				assert.Equal(t, tt.expectedValue, *build.Spec.ParamValues[0].SingleValue.Value)
+			}
+		})
+	}
+}
+
 func TestGetServiceAccountFilePath(t *testing.T) {
 	tests := []struct {
 		name           string

--- a/convert/rfe.go
+++ b/convert/rfe.go
@@ -1,7 +1,6 @@
 package convert
 
 const (
-	ForcePullFlagRFE         = "https://issues.redhat.com/browse/BUILD-1580"
 	ConfigMapsRFE            = "https://issues.redhat.com/browse/BUILD-1745"
 	SecretsRFE               = "https://issues.redhat.com/browse/BUILD-1744"
 	DockerStrategyVolumesRFE = "https://issues.redhat.com/browse/BUILD-1747"


### PR DESCRIPTION
## Summary
- Map BuildConfig `DockerStrategy.ForcePull: true` to Shipwright Build `pull: always` param
- Add `ForcePullParamName = "pull"` constant and `processDockerStrategyForcePull` method
- Remove `ForcePullFlagRFE` from rfe.go (feature now implemented)
- Add table-driven unit tests (ForcePull true/false cases)

## Test plan
- [x] Unit tests: 79/79 PASS
- [x] Cluster test: Strategy validation on OpenShift 4.20.0-0.nightly — control vs pull=always confirmed behavioral difference
- [x] Cluster test: Full e2e pipeline — BuildConfig(forcePull:true) → crane convert → Build(pull:always) → BuildRun success

## Dependencies
- Operator PR must merge first: https://github.com/redhat-openshift-builds/operator/pull/1386

## Related
- Jira: https://issues.redhat.com/browse/BUILD-1580

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Docker builds now support the `forcePull` setting during conversion.
  * When enabled, the resulting build is configured to always pull the latest image.
* **Bug Fixes**
  * The prior “unsupported setting” warning has been replaced with actual build parameter generation for `forcePull`.
* **Tests**
  * Added unit coverage verifying correct parameter behavior when `forcePull` is enabled vs disabled.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->