### PR TITLE
[BUILD-1581] feat: map ImageOptimizationPolicy to buildah squash parameter

### DIFF
--- a/convert/buildconfigs.go
+++ b/convert/buildconfigs.go
@@ -41,6 +41,7 @@ const (
 
 	// Buildah Strategy Param Names
 	NoCacheParamName          = "no-cache"
+	SquashParamName           = "squash"
 	RuntimeStageFromParamName = "runtime-stage-from"
 
 	Timeout = 10 * time.Minute
@@ -146,9 +147,7 @@ func (t *ConvertOptions) convertBuildConfigs() error {
 			t.processBuildArgs(bc, b)
 
 			// process ImageOptimizationPolicy field
-			if bc.Spec.Strategy.DockerStrategy.ImageOptimizationPolicy != nil {
-				t.Logger.Warnf("ImageOptimizationPolicy (--squash) flag is not yet supported in the built-in Buildah ClusterBuildStrategy in Shipwright. RFE: %s", SqashFlagRFE)
-			}
+			t.processDockerStrategySquash(&bc, b)
 
 			// process volumes
 			if len(bc.Spec.Strategy.DockerStrategy.Volumes) > 0 {
@@ -974,6 +973,39 @@ func (t *ConvertOptions) processDockerStrategyNoCache(bc *buildv1.BuildConfig, b
 	}
 }
 
+func (t *ConvertOptions) processDockerStrategySquash(bc *buildv1.BuildConfig, b *shipwrightv1beta1.Build) {
+	if bc.Spec.Strategy.DockerStrategy.ImageOptimizationPolicy == nil {
+		return
+	}
+
+	policy := *bc.Spec.Strategy.DockerStrategy.ImageOptimizationPolicy
+	switch policy {
+	case buildv1.ImageOptimizationSkipLayers:
+		t.Logger.Infof("Mapping ImageOptimizationPolicy SkipLayers to squash param for BuildConfig %s", bc.Name)
+		squashValue := "true"
+		squashParam := shipwrightv1beta1.ParamValue{
+			Name: SquashParamName,
+			SingleValue: &shipwrightv1beta1.SingleValue{
+				Value: &squashValue,
+			},
+		}
+		b.Spec.ParamValues = append(b.Spec.ParamValues, squashParam)
+	case buildv1.ImageOptimizationSkipLayersAndWarn:
+		t.Logger.Infof("Mapping ImageOptimizationPolicy SkipLayersAndWarn to squash param for BuildConfig %s (warn variant has no equivalent in buildah, treating as squash)", bc.Name)
+		squashValue := "true"
+		squashParam := shipwrightv1beta1.ParamValue{
+			Name: SquashParamName,
+			SingleValue: &shipwrightv1beta1.SingleValue{
+				Value: &squashValue,
+			},
+		}
+		b.Spec.ParamValues = append(b.Spec.ParamValues, squashParam)
+	case buildv1.ImageOptimizationNone:
+		t.Logger.Infof("ImageOptimizationPolicy is None for BuildConfig %s, no squash param needed", bc.Name)
+	default:
+		t.Logger.Warnf("Unknown ImageOptimizationPolicy %q for BuildConfig %s", policy, bc.Name)
+	}
+}
 
 func getBuildFilePath(b shipwrightv1beta1.Build) string {
 	return strings.Join([]string{b.GroupVersionKind().Kind, b.GroupVersionKind().Group, b.GroupVersionKind().Version, b.Namespace, b.Name}, "_") + ".yaml"

--- a/convert/buildconfigs_test.go
+++ b/convert/buildconfigs_test.go
@@ -1969,6 +1969,113 @@ func TestProcessDockerStrategyNoCache(t *testing.T) {
 }
 
 
+func TestProcessDockerStrategySquash(t *testing.T) {
+	skipLayers := buildv1.ImageOptimizationSkipLayers
+	skipLayersAndWarn := buildv1.ImageOptimizationSkipLayersAndWarn
+	none := buildv1.ImageOptimizationNone
+
+	tests := []struct {
+		name           string
+		buildConfig    *buildv1.BuildConfig
+		expectedParams int
+		expectedName   string
+		expectedValue  string
+	}{
+		{
+			name: "SkipLayers - maps to squash=true",
+			buildConfig: &buildv1.BuildConfig{
+				ObjectMeta: metav1.ObjectMeta{Name: "test-bc"},
+				Spec: buildv1.BuildConfigSpec{
+					CommonSpec: buildv1.CommonSpec{
+						Strategy: buildv1.BuildStrategy{
+							Type: buildv1.DockerBuildStrategyType,
+							DockerStrategy: &buildv1.DockerBuildStrategy{
+								ImageOptimizationPolicy: &skipLayers,
+							},
+						},
+					},
+				},
+			},
+			expectedParams: 1,
+			expectedName:   "squash",
+			expectedValue:  "true",
+		},
+		{
+			name: "SkipLayersAndWarn - maps to squash=true",
+			buildConfig: &buildv1.BuildConfig{
+				ObjectMeta: metav1.ObjectMeta{Name: "test-bc"},
+				Spec: buildv1.BuildConfigSpec{
+					CommonSpec: buildv1.CommonSpec{
+						Strategy: buildv1.BuildStrategy{
+							Type: buildv1.DockerBuildStrategyType,
+							DockerStrategy: &buildv1.DockerBuildStrategy{
+								ImageOptimizationPolicy: &skipLayersAndWarn,
+							},
+						},
+					},
+				},
+			},
+			expectedParams: 1,
+			expectedName:   "squash",
+			expectedValue:  "true",
+		},
+		{
+			name: "None - no param added",
+			buildConfig: &buildv1.BuildConfig{
+				ObjectMeta: metav1.ObjectMeta{Name: "test-bc"},
+				Spec: buildv1.BuildConfigSpec{
+					CommonSpec: buildv1.CommonSpec{
+						Strategy: buildv1.BuildStrategy{
+							Type: buildv1.DockerBuildStrategyType,
+							DockerStrategy: &buildv1.DockerBuildStrategy{
+								ImageOptimizationPolicy: &none,
+							},
+						},
+					},
+				},
+			},
+			expectedParams: 0,
+		},
+		{
+			name: "nil - no param added",
+			buildConfig: &buildv1.BuildConfig{
+				ObjectMeta: metav1.ObjectMeta{Name: "test-bc"},
+				Spec: buildv1.BuildConfigSpec{
+					CommonSpec: buildv1.CommonSpec{
+						Strategy: buildv1.BuildStrategy{
+							Type: buildv1.DockerBuildStrategyType,
+							DockerStrategy: &buildv1.DockerBuildStrategy{
+								ImageOptimizationPolicy: nil,
+							},
+						},
+					},
+				},
+			},
+			expectedParams: 0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			co := &ConvertOptions{
+				Logger: logrus.New(),
+			}
+			build := &shipwrightv1beta1.Build{
+				Spec: shipwrightv1beta1.BuildSpec{},
+			}
+
+			co.processDockerStrategySquash(tt.buildConfig, build)
+
+			assert.Equal(t, tt.expectedParams, len(build.Spec.ParamValues))
+
+			if tt.expectedParams > 0 {
+				assert.Equal(t, tt.expectedName, build.Spec.ParamValues[0].Name)
+				assert.Equal(t, tt.expectedValue, *build.Spec.ParamValues[0].SingleValue.Value)
+			}
+		})
+	}
+}
+
 // Helper function to create string pointers
 func stringPtr(s string) *string {
 	return &s

--- a/convert/rfe.go
+++ b/convert/rfe.go
@@ -2,7 +2,6 @@ package convert
 
 const (
 	ForcePullFlagRFE         = "https://issues.redhat.com/browse/BUILD-1580"
-	SqashFlagRFE             = "https://issues.redhat.com/browse/BUILD-1581"
 	ConfigMapsRFE            = "https://issues.redhat.com/browse/BUILD-1745"
 	SecretsRFE               = "https://issues.redhat.com/browse/BUILD-1744"
 	DockerStrategyVolumesRFE = "https://issues.redhat.com/browse/BUILD-1747"


### PR DESCRIPTION
## Summary
- Map BuildConfig `DockerStrategy.ImageOptimizationPolicy` to Shipwright Build `squash` param
- SkipLayers and SkipLayersAndWarn both map to `squash: "true"`; None and nil add no param
- Add `SquashParamName = "squash"` constant and `processDockerStrategySquash` method
- Remove `SqashFlagRFE` from rfe.go (feature now implemented)
- Add table-driven unit tests (4 cases: SkipLayers, SkipLayersAndWarn, None, nil)

## Test plan
- [x] Unit tests: 81/81 PASS
- [x] Cluster test: Strategy validation — control vs squash BuildRuns both succeeded
- [x] Cluster test: Full e2e pipeline — BuildConfig(imageOptimizationPolicy:SkipLayers) → crane convert → Build(squash:true) → BuildRun success

## Dependencies
- Operator PR must merge first: https://github.com/redhat-openshift-builds/operator/pull/1387

## Related
- Jira: https://issues.redhat.com/browse/BUILD-1581

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Docker build conversions now support image layer optimization by adding the `squash=true` build parameter when configured.
  * Unsupported optimization policies generate a warning.
* **Bug Fixes**
  * Preserved behavior for disabled or unspecified optimization policies without adding unnecessary parameters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->