### PR TITLE
:bug: fixed stale secret whiteout and SA reference

### DIFF
--- a/transform/kubernetes/kubernetes.go
+++ b/transform/kubernetes/kubernetes.go
@@ -268,6 +268,13 @@ func (k *KubernetesTransformPlugin) getWhiteOuts(obj unstructured.Unstructured) 
 			return true
 		}
 	}
+	if groupKind == secretGK {
+		secretType, _, _ := unstructured.NestedString(obj.Object, "type")
+		switch secretType {
+		case "kubernetes.io/service-account-token", "kubernetes.io/dockercfg":
+			return true
+		}
+	}
 	if k.DisableWhiteoutOwned {
 		return false
 	}
@@ -517,6 +524,15 @@ func (k *KubernetesTransformPlugin) getKubernetesTransforms(obj unstructured.Uns
 			return nil, err
 		}
 		jsonPatch = append(jsonPatch, patches...)
+	}
+	if serviceAccountGK == obj.GetObjectKind().GroupVersionKind().GroupKind() {
+		if _, found, _ := unstructured.NestedSlice(obj.Object, "secrets"); found {
+			patch, err := jsonpatch.DecodePatch([]byte(fmt.Sprintf(opRemove, "/secrets")))
+			if err != nil {
+				return nil, err
+			}
+			jsonPatch = append(jsonPatch, patch...)
+		}
 	}
 	if k.RegistryReplacement != nil && len(k.RegistryReplacement) > 0 {
 		if podGK == obj.GetObjectKind().GroupVersionKind().GroupKind() {

--- a/transform/kubernetes/kubernetes.go
+++ b/transform/kubernetes/kubernetes.go
@@ -269,10 +269,11 @@ func (k *KubernetesTransformPlugin) getWhiteOuts(obj unstructured.Unstructured) 
 		}
 	}
 	if groupKind == secretGK {
-		secretType, _, _ := unstructured.NestedString(obj.Object, "type")
-		switch secretType {
-		case "kubernetes.io/service-account-token", "kubernetes.io/dockercfg":
-			return true
+		if secretType, found, _ := unstructured.NestedString(obj.Object, "type"); found {
+			switch secretType {
+			case "kubernetes.io/service-account-token", "kubernetes.io/dockercfg":
+				return true
+			}
 		}
 	}
 	if k.DisableWhiteoutOwned {

--- a/transform/kubernetes/kubernetes_test.go
+++ b/transform/kubernetes/kubernetes_test.go
@@ -28,6 +28,7 @@ func TestRun(t *testing.T) {
 		ShouldError          bool
 		Response             transform.PluginResponse
 		PatchResponseJson    string
+		ExpectNoPatches      bool
 	}{
 		{
 			Name: "EnpointWhiteOut",
@@ -1141,6 +1142,7 @@ func TestRun(t *testing.T) {
 				IsWhiteOut: false,
 				Version:    "v1",
 			},
+			ExpectNoPatches: true,
 		},
 	}
 
@@ -1180,6 +1182,10 @@ func TestRun(t *testing.T) {
 				} else {
 					t.Error(fmt.Sprintf("Patches Expected: %#v, none found", expectPatch))
 				}
+			}
+			if c.ExpectNoPatches && len(resp.Patches) != 0 {
+				actual, _ := json.Marshal(resp.Patches)
+				t.Errorf("Expected no patches but got: %s", actual)
 			}
 		})
 	}

--- a/transform/kubernetes/kubernetes_test.go
+++ b/transform/kubernetes/kubernetes_test.go
@@ -1021,6 +1021,127 @@ func TestRun(t *testing.T) {
 				Version:    "v1",
 			},
 		},
+		{
+			Name: "SATokenSecretWhiteOut",
+			Object: &unstructured.Unstructured{
+				Object: map[string]interface{}{
+					"kind":       "Secret",
+					"apiVersion": "v1",
+					"type":       "kubernetes.io/service-account-token",
+					"metadata": map[string]interface{}{
+						"name":      "app-sa-token-xwzl7",
+						"namespace": "myapp",
+						"annotations": map[string]interface{}{
+							"kubernetes.io/service-account.name": "app-sa",
+						},
+					},
+				},
+			},
+			Response: transform.PluginResponse{
+				IsWhiteOut: true,
+				Version:    "v1",
+			},
+		},
+		{
+			Name: "DockercfgSecretWhiteOut",
+			Object: &unstructured.Unstructured{
+				Object: map[string]interface{}{
+					"kind":       "Secret",
+					"apiVersion": "v1",
+					"type":       "kubernetes.io/dockercfg",
+					"metadata": map[string]interface{}{
+						"name":      "builder-dockercfg-abc12",
+						"namespace": "myapp",
+						"annotations": map[string]interface{}{
+							"kubernetes.io/service-account.name": "builder",
+						},
+					},
+				},
+			},
+			Response: transform.PluginResponse{
+				IsWhiteOut: true,
+				Version:    "v1",
+			},
+		},
+		{
+			Name: "OpaqueSecretNotWhiteOut",
+			Object: &unstructured.Unstructured{
+				Object: map[string]interface{}{
+					"kind":       "Secret",
+					"apiVersion": "v1",
+					"type":       "Opaque",
+					"metadata": map[string]interface{}{
+						"name":      "my-app-secret",
+						"namespace": "myapp",
+					},
+					"data": map[string]interface{}{
+						"password": "c2VjcmV0",
+					},
+				},
+			},
+			Response: transform.PluginResponse{
+				IsWhiteOut: false,
+				Version:    "v1",
+			},
+		},
+		{
+			Name: "TLSSecretNotWhiteOut",
+			Object: &unstructured.Unstructured{
+				Object: map[string]interface{}{
+					"kind":       "Secret",
+					"apiVersion": "v1",
+					"type":       "kubernetes.io/tls",
+					"metadata": map[string]interface{}{
+						"name":      "my-tls-cert",
+						"namespace": "myapp",
+					},
+				},
+			},
+			Response: transform.PluginResponse{
+				IsWhiteOut: false,
+				Version:    "v1",
+			},
+		},
+		{
+			Name: "ServiceAccountSecretsFieldStripped",
+			Object: &unstructured.Unstructured{
+				Object: map[string]interface{}{
+					"kind":       "ServiceAccount",
+					"apiVersion": "v1",
+					"metadata": map[string]interface{}{
+						"name":      "app-sa",
+						"namespace": "myapp",
+					},
+					"secrets": []interface{}{
+						map[string]interface{}{
+							"name": "app-sa-token-xwzl7",
+						},
+					},
+				},
+			},
+			Response: transform.PluginResponse{
+				IsWhiteOut: false,
+				Version:    "v1",
+			},
+			PatchResponseJson: `[{"op": "remove", "path": "/secrets"}]`,
+		},
+		{
+			Name: "ServiceAccountWithoutSecretsFieldUntouched",
+			Object: &unstructured.Unstructured{
+				Object: map[string]interface{}{
+					"kind":       "ServiceAccount",
+					"apiVersion": "v1",
+					"metadata": map[string]interface{}{
+						"name":      "app-sa",
+						"namespace": "myapp",
+					},
+				},
+			},
+			Response: transform.PluginResponse{
+				IsWhiteOut: false,
+				Version:    "v1",
+			},
+		},
 	}
 
 	for _, c := range cases {


### PR DESCRIPTION
## Summary

  Whiteout auto-generated SA token Secrets (`kubernetes.io/service-account-token`) and OCP dockercfg Secrets (`kubernetes.io/dockercfg`) by Secret type, regardless of ownerReferences. Also strip the `secrets` field from
  ServiceAccounts to remove dangling references to source-cluster token Secrets.

  ## Problem

  When migrating from Kubernetes < 1.24, auto-generated ServiceAccount token Secrets have **no ownerReferences**. The KubernetesPlugin only whiteouts resources that have ownerReferences, so these Secrets pass through the
  entire pipeline and are applied to the target with stale source-cluster credentials (JWT signed by the wrong key, wrong CA cert, wrong SA UID).

  On the target:
  - **K8s >= 1.24**: Secret is created then silently deleted by the token controller (UID mismatch). No error surfaced, but the SA has a dangling `secrets` reference.
  - **K8s < 1.24**: Secret persists with invalid credentials. Pods get a JWT token signed by the source cluster's key. All API calls fail with "Unauthorized".

  Same issue applies to OCP dockercfg Secrets on older OCP versions where they lack ownerReferences.

  ## Changes

  **1. Whiteout Secrets by type** (`getWhiteOuts()`)

  Added a type-based check before the ownerReferences check. Secrets of type `kubernetes.io/service-account-token` and `kubernetes.io/dockercfg` are always whiteout-ed. These are cluster-generated credentials that are
  never valid on a different cluster. The target's controllers regenerate them automatically.

  User-created Secrets (`Opaque`, `kubernetes.io/tls`, etc.) are unaffected.

  **2. Strip SA `secrets` field** (`getKubernetesTransforms()`)

  Added a JSONPatch `remove /secrets` for ServiceAccounts that have a `secrets` field. This field carries source-specific token Secret names that don't exist on the target. The target cluster's token controller
  repopulates it with fresh references.

  ## Migration matrix

  | Scenario | Before | After |
  |----------|--------|-------|
  | Old K8s → Old K8s | Stale token Secret persists, pods get invalid JWT | Fixed — whiteout-ed, target generates fresh one |
  | Old OCP → Old OCP | Stale token + dockercfg Secrets persist | Fixed — both whiteout-ed, target regenerates |
  | New K8s → New K8s | No issue (no token Secret to export) | No change |
  | New OCP → New OCP | No issue (ownerRef check already works) | No change |
  | Old K8s → New K8s | Secret silently created and deleted, dangling SA ref | Fixed — whiteout-ed, target uses projected tokens |
  | Old OCP → New OCP | Same as above + dockercfg | Fixed — both whiteout-ed |

  Fixes: crane#484

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Kubernetes resource cleanup by correctly handling service-account-token and dockercfg Secrets.
  * Prevented unrelated Opaque and TLS Secrets from being removed.
  * Removed legacy Secret references from ServiceAccounts when present.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->