### PR TITLE
[BUILD-1606] feat: map S2I ForcePull to pull-policy parameter

### DIFF
--- a/convert/buildconfigs.go
+++ b/convert/buildconfigs.go
@@ -48,6 +48,7 @@ const (
 	// S2I Strategy Parameters
 	S2iScriptsURLParamName  = "scripts-url"
 	S2iIncrementalParamName = "incremental"
+	S2iForcePullParamName   = "pull-policy"
 
 	Timeout = 10 * time.Minute
 )
@@ -200,10 +201,7 @@ func (t *ConvertOptions) convertBuildConfigs() error {
 
 			t.processSourceStrategyIncremental(&bc, b)
 
-			// process force pull field
-			if bc.Spec.Strategy.SourceStrategy.ForcePull {
-				t.Logger.Warnf("ForcePull flag is not yet supported in the built-in Source-to-Image ClusterBuildStrategy in Shipwright. RFE: %s", ForcePullFlagS2iRFE)
-			}
+			t.processSourceStrategyForcePull(&bc, b)
 
 			// process volumes
 			if len(bc.Spec.Strategy.SourceStrategy.Volumes) > 0 {
@@ -1043,6 +1041,20 @@ func (t *ConvertOptions) processSourceStrategyIncremental(bc *buildv1.BuildConfi
 			},
 		}
 		b.Spec.ParamValues = append(b.Spec.ParamValues, incrementalParam)
+	}
+}
+
+func (t *ConvertOptions) processSourceStrategyForcePull(bc *buildv1.BuildConfig, b *shipwrightv1beta1.Build) {
+	if bc.Spec.Strategy.SourceStrategy.ForcePull {
+		t.Logger.Infof("Mapping ForcePull flag to pull-policy param for BuildConfig %s", bc.Name)
+		pullPolicyValue := "always"
+		pullPolicyParam := shipwrightv1beta1.ParamValue{
+			Name: S2iForcePullParamName,
+			SingleValue: &shipwrightv1beta1.SingleValue{
+				Value: &pullPolicyValue,
+			},
+		}
+		b.Spec.ParamValues = append(b.Spec.ParamValues, pullPolicyParam)
 	}
 }
 

--- a/convert/buildconfigs_test.go
+++ b/convert/buildconfigs_test.go
@@ -51,11 +51,6 @@ func (m *MockClient) Get(ctx context.Context, key client.ObjectKey, obj client.O
 	return nil
 }
 
-func (m *MockClient) Apply(ctx context.Context, obj runtime.ApplyConfiguration, opts ...client.ApplyOption) error {
-	args := m.Called(ctx, obj, opts)
-	return args.Error(0)
-}
-
 func (m *MockClient) List(ctx context.Context, list client.ObjectList, opts ...client.ListOption) error {
 	args := m.Called(ctx, list, opts)
 	if args.Get(0) != nil {

--- a/convert/buildconfigs_test.go
+++ b/convert/buildconfigs_test.go
@@ -51,6 +51,11 @@ func (m *MockClient) Get(ctx context.Context, key client.ObjectKey, obj client.O
 	return nil
 }
 
+func (m *MockClient) Apply(ctx context.Context, obj runtime.ApplyConfiguration, opts ...client.ApplyOption) error {
+	args := m.Called(ctx, obj, opts)
+	return args.Error(0)
+}
+
 func (m *MockClient) List(ctx context.Context, list client.ObjectList, opts ...client.ListOption) error {
 	args := m.Called(ctx, list, opts)
 	if args.Get(0) != nil {
@@ -2072,6 +2077,81 @@ func TestProcessSourceStrategyIncremental(t *testing.T) {
 			}
 
 			co.processSourceStrategyIncremental(tt.buildConfig, build)
+
+			assert.Equal(t, tt.expectedParams, len(build.Spec.ParamValues))
+
+			if tt.expectedParams > 0 {
+				assert.Equal(t, tt.expectedName, build.Spec.ParamValues[0].Name)
+				assert.Equal(t, tt.expectedValue, *build.Spec.ParamValues[0].SingleValue.Value)
+			}
+		})
+	}
+}
+
+func TestProcessSourceStrategyForcePull(t *testing.T) {
+	tests := []struct {
+		name           string
+		buildConfig    *buildv1.BuildConfig
+		expectedParams int
+		expectedName   string
+		expectedValue  string
+	}{
+		{
+			name: "ForcePull true - maps to pull-policy=always",
+			buildConfig: &buildv1.BuildConfig{
+				ObjectMeta: metav1.ObjectMeta{Name: "test-bc"},
+				Spec: buildv1.BuildConfigSpec{
+					CommonSpec: buildv1.CommonSpec{
+						Strategy: buildv1.BuildStrategy{
+							Type: buildv1.SourceBuildStrategyType,
+							SourceStrategy: &buildv1.SourceBuildStrategy{
+								ForcePull: true,
+								From: corev1.ObjectReference{
+									Kind: "DockerImage",
+									Name: "registry.access.redhat.com/ubi9/nodejs-18:latest",
+								},
+							},
+						},
+					},
+				},
+			},
+			expectedParams: 1,
+			expectedName:   "pull-policy",
+			expectedValue:  "always",
+		},
+		{
+			name: "ForcePull false - no param added",
+			buildConfig: &buildv1.BuildConfig{
+				ObjectMeta: metav1.ObjectMeta{Name: "test-bc"},
+				Spec: buildv1.BuildConfigSpec{
+					CommonSpec: buildv1.CommonSpec{
+						Strategy: buildv1.BuildStrategy{
+							Type: buildv1.SourceBuildStrategyType,
+							SourceStrategy: &buildv1.SourceBuildStrategy{
+								ForcePull: false,
+								From: corev1.ObjectReference{
+									Kind: "DockerImage",
+									Name: "registry.access.redhat.com/ubi9/nodejs-18:latest",
+								},
+							},
+						},
+					},
+				},
+			},
+			expectedParams: 0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			co := &ConvertOptions{
+				Logger: logrus.New(),
+			}
+			build := &shipwrightv1beta1.Build{
+				Spec: shipwrightv1beta1.BuildSpec{},
+			}
+
+			co.processSourceStrategyForcePull(tt.buildConfig, build)
 
 			assert.Equal(t, tt.expectedParams, len(build.Spec.ParamValues))
 

--- a/convert/rfe.go
+++ b/convert/rfe.go
@@ -6,6 +6,5 @@ const (
 	DockerStrategyVolumesRFE = "https://issues.redhat.com/browse/BUILD-1747"
 	CustomScriptsRFE         = "https://issues.redhat.com/browse/BUILD-1641"
 	IncrementalBuildRFE      = "https://issues.redhat.com/browse/BUILD-1607"
-	ForcePullFlagS2iRFE      = "https://issues.redhat.com/browse/BUILD-1606"
 	PullSecretS2IRFE         = "https://issues.redhat.com/browse/BUILD-1749"
 )


### PR DESCRIPTION
## Summary
- Maps BuildConfig `SourceStrategy.ForcePull=true` to the Shipwright S2I strategy param `pull-policy=always` via new `processSourceStrategyForcePull()` (replaces the previous warn-only behavior)
- Adds `S2iForcePullParamName = "pull-policy"` constant; `ForcePull=false` adds no param (strategy default `if-not-present` preserved)
- Removes the now-obsolete `ForcePullFlagS2iRFE` constant from `convert/rfe.go`

## Test plan
- [x] Unit tests: 87/87 PASS (`GOWORK=off go test ./convert/...`)
- [x] Cluster e2e (2026-07-28): converted Build with `pull-policy=always` applied on OpenShift; BuildRun `test-conversion-run-1` Succeeded

## Dependencies
- Operator PR must merge first: https://github.com/redhat-openshift-builds/operator/pull/1388 (adds the `pull-policy` param to the source-to-image ClusterBuildStrategy)

## Related
- Jira: https://issues.redhat.com/browse/BUILD-1606

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Source-to-Image builds now honor the `ForcePull` setting by applying an `always` image pull policy during conversion.

- **Bug Fixes**
  - Improved consistency between OpenShift Source strategies and generated Shipwright build settings.

- **Tests**
  - Added coverage verifying pull-policy behavior when `ForcePull` is enabled or disabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->