### PR TITLE
[BUILD-1641] feat: map SourceStrategy Scripts to S2I scripts-url param

### DIFF
--- a/convert/buildconfigs.go
+++ b/convert/buildconfigs.go
@@ -45,6 +45,9 @@ const (
 	ForcePullParamName        = "pull"
 	RuntimeStageFromParamName = "runtime-stage-from"
 
+	// S2I Strategy Parameters
+	S2iScriptsURLParamName = "scripts-url"
+
 	Timeout = 10 * time.Minute
 )
 
@@ -192,10 +195,7 @@ func (t *ConvertOptions) convertBuildConfigs() error {
 				b.Spec.Env = append(b.Spec.Env, bc.Spec.Strategy.SourceStrategy.Env...)
 			}
 
-			// process custom scripts
-			if bc.Spec.Strategy.SourceStrategy.Scripts != "" {
-				t.Logger.Warnf("Custom scripts are not yet supported in the built-in Source-to-Image ClusterBuildStrategy in Shipwright. RFE: %s", CustomScriptsRFE)
-			}
+			t.processSourceStrategyScripts(&bc, b)
 
 			// process incremental build
 			if bc.Spec.Strategy.SourceStrategy.Incremental != nil {
@@ -955,6 +955,20 @@ func (t *ConvertOptions) processBuildArgs(bc buildv1.BuildConfig, b *shipwrightv
 			Values: values,
 		}
 		b.Spec.ParamValues = append(b.Spec.ParamValues, buildArgsParam)
+	}
+}
+
+func (t *ConvertOptions) processSourceStrategyScripts(bc *buildv1.BuildConfig, b *shipwrightv1beta1.Build) {
+	if bc.Spec.Strategy.SourceStrategy.Scripts != "" {
+		t.Logger.Infof("Mapping Scripts URL to scripts-url param for BuildConfig %s", bc.Name)
+		scriptsURL := bc.Spec.Strategy.SourceStrategy.Scripts
+		scriptsParam := shipwrightv1beta1.ParamValue{
+			Name: S2iScriptsURLParamName,
+			SingleValue: &shipwrightv1beta1.SingleValue{
+				Value: &scriptsURL,
+			},
+		}
+		b.Spec.ParamValues = append(b.Spec.ParamValues, scriptsParam)
 	}
 }
 

--- a/convert/buildconfigs_test.go
+++ b/convert/buildconfigs_test.go
@@ -1909,6 +1909,81 @@ func TestProcessDockerStrategyForcePull(t *testing.T) {
 	}
 }
 
+func TestProcessSourceStrategyScripts(t *testing.T) {
+	tests := []struct {
+		name           string
+		buildConfig    *buildv1.BuildConfig
+		expectedParams int
+		expectedName   string
+		expectedValue  string
+	}{
+		{
+			name: "Scripts URL set - maps to scripts-url param",
+			buildConfig: &buildv1.BuildConfig{
+				ObjectMeta: metav1.ObjectMeta{Name: "test-bc"},
+				Spec: buildv1.BuildConfigSpec{
+					CommonSpec: buildv1.CommonSpec{
+						Strategy: buildv1.BuildStrategy{
+							Type: buildv1.SourceBuildStrategyType,
+							SourceStrategy: &buildv1.SourceBuildStrategy{
+								Scripts: "https://example.com/s2i/scripts",
+								From: corev1.ObjectReference{
+									Kind: "DockerImage",
+									Name: "registry.access.redhat.com/ubi9/nodejs-18:latest",
+								},
+							},
+						},
+					},
+				},
+			},
+			expectedParams: 1,
+			expectedName:   "scripts-url",
+			expectedValue:  "https://example.com/s2i/scripts",
+		},
+		{
+			name: "Scripts URL empty - no param added",
+			buildConfig: &buildv1.BuildConfig{
+				ObjectMeta: metav1.ObjectMeta{Name: "test-bc"},
+				Spec: buildv1.BuildConfigSpec{
+					CommonSpec: buildv1.CommonSpec{
+						Strategy: buildv1.BuildStrategy{
+							Type: buildv1.SourceBuildStrategyType,
+							SourceStrategy: &buildv1.SourceBuildStrategy{
+								Scripts: "",
+								From: corev1.ObjectReference{
+									Kind: "DockerImage",
+									Name: "registry.access.redhat.com/ubi9/nodejs-18:latest",
+								},
+							},
+						},
+					},
+				},
+			},
+			expectedParams: 0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			co := &ConvertOptions{
+				Logger: logrus.New(),
+			}
+			build := &shipwrightv1beta1.Build{
+				Spec: shipwrightv1beta1.BuildSpec{},
+			}
+
+			co.processSourceStrategyScripts(tt.buildConfig, build)
+
+			assert.Equal(t, tt.expectedParams, len(build.Spec.ParamValues))
+
+			if tt.expectedParams > 0 {
+				assert.Equal(t, tt.expectedName, build.Spec.ParamValues[0].Name)
+				assert.Equal(t, tt.expectedValue, *build.Spec.ParamValues[0].SingleValue.Value)
+			}
+		})
+	}
+}
+
 func TestGetServiceAccountFilePath(t *testing.T) {
 	tests := []struct {
 		name           string
@@ -2034,7 +2109,6 @@ func TestProcessDockerStrategyNoCache(t *testing.T) {
 		})
 	}
 }
-
 
 func TestProcessDockerStrategySquash(t *testing.T) {
 	skipLayers := buildv1.ImageOptimizationSkipLayers

--- a/convert/rfe.go
+++ b/convert/rfe.go
@@ -4,7 +4,6 @@ const (
 	ConfigMapsRFE            = "https://issues.redhat.com/browse/BUILD-1745"
 	SecretsRFE               = "https://issues.redhat.com/browse/BUILD-1744"
 	DockerStrategyVolumesRFE = "https://issues.redhat.com/browse/BUILD-1747"
-	CustomScriptsRFE         = "https://issues.redhat.com/browse/BUILD-1641"
 	IncrementalBuildRFE      = "https://issues.redhat.com/browse/BUILD-1607"
 	ForcePullFlagS2iRFE      = "https://issues.redhat.com/browse/BUILD-1606"
 	PullSecretS2IRFE         = "https://issues.redhat.com/browse/BUILD-1749"


### PR DESCRIPTION
## Summary
- Maps BuildConfig `sourceStrategy.scripts` to the Shipwright S2I `scripts-url` build parameter during conversion
- Adds `S2iScriptsURLParamName = "scripts-url"` exported constant and `processSourceStrategyScripts()` (replaces the previous unsupported-field warning)
- Removes the now-dead `CustomScriptsRFE` constant

## Test plan
- [x] `GOWORK=off go test ./convert/...`: 87/87 PASS (post-rebase onto latest main)
- [x] `TestProcessSourceStrategyScripts`: table-driven — URL set → param added; empty → no param emitted
- [x] Full results: designs/test-results/BUILD-1641-results.md

## Dependencies
Operator PR must merge first (defines the `scripts-url` strategy param): operator PR: https://github.com/redhat-openshift-builds/operator/pull/1390

## Related
- Jira: https://issues.redhat.com/browse/BUILD-1641

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Build conversion now supports custom Source-to-Image script URLs.
  * Custom script URLs are preserved as build parameters during conversion.

* **Bug Fixes**
  * Source strategies with configured scripts are no longer ignored during BuildConfig conversion.

* **Tests**
  * Added coverage for configured and empty script URL scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->