### PR TITLE
:sparkles: Rclone indirect transfer engine

### DIFF
--- a/state_transfer/transfer/indirect/cleanup.go
+++ b/state_transfer/transfer/indirect/cleanup.go
@@ -1,0 +1,25 @@
+package indirect
+
+import (
+	"context"
+	"fmt"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+func (t *IndirectTransfer) Cleanup(ctx context.Context, c client.Client, namespace string) error {
+	podList := &corev1.PodList{}
+	if err := c.List(ctx, podList,
+		client.InNamespace(namespace),
+		client.MatchingLabels(t.options.Labels)); err != nil {
+		return fmt.Errorf("failed to list indirect transfer pods: %w", err)
+	}
+	for i := range podList.Items {
+		if err := c.Delete(ctx, &podList.Items[i]); err != nil && !errors.IsNotFound(err) {
+			return fmt.Errorf("failed to delete pod %s: %w", podList.Items[i].Name, err)
+		}
+	}
+	return nil
+}

--- a/state_transfer/transfer/indirect/cleanup.go
+++ b/state_transfer/transfer/indirect/cleanup.go
@@ -11,10 +11,12 @@ import (
 
 func (t *IndirectTransfer) Cleanup(ctx context.Context, c client.Client, namespace, pvcName string) error {
 	if len(t.options.Labels) == 0 {
-		return fmt.Errorf("refusing to cleanup with empty labels: would match all pods in namespace %s", namespace)
+		return fmt.Errorf("refusing to cleanup with empty labels: would match all resources in namespace %s", namespace)
 	}
 	cleanupLabels := copyLabels(t.options.Labels)
 	cleanupLabels["app.konveyor.io/created-for-pvc"] = pvcName
+
+	// Delete pods
 	podList := &corev1.PodList{}
 	if err := c.List(ctx, podList,
 		client.InNamespace(namespace),
@@ -26,5 +28,19 @@ func (t *IndirectTransfer) Cleanup(ctx context.Context, c client.Client, namespa
 			return fmt.Errorf("failed to delete pod %s: %w", podList.Items[i].Name, err)
 		}
 	}
+
+	// Delete secrets
+	secretList := &corev1.SecretList{}
+	if err := c.List(ctx, secretList,
+		client.InNamespace(namespace),
+		client.MatchingLabels(cleanupLabels)); err != nil {
+		return fmt.Errorf("failed to list indirect transfer secrets: %w", err)
+	}
+	for i := range secretList.Items {
+		if err := c.Delete(ctx, &secretList.Items[i]); err != nil && !errors.IsNotFound(err) {
+			return fmt.Errorf("failed to delete secret %s: %w", secretList.Items[i].Name, err)
+		}
+	}
+
 	return nil
 }

--- a/state_transfer/transfer/indirect/cleanup.go
+++ b/state_transfer/transfer/indirect/cleanup.go
@@ -10,6 +10,9 @@ import (
 )
 
 func (t *IndirectTransfer) Cleanup(ctx context.Context, c client.Client, namespace string) error {
+	if len(t.options.Labels) == 0 {
+		return fmt.Errorf("refusing to cleanup with empty labels: would match all pods in namespace %s", namespace)
+	}
 	podList := &corev1.PodList{}
 	if err := c.List(ctx, podList,
 		client.InNamespace(namespace),

--- a/state_transfer/transfer/indirect/cleanup.go
+++ b/state_transfer/transfer/indirect/cleanup.go
@@ -9,14 +9,16 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-func (t *IndirectTransfer) Cleanup(ctx context.Context, c client.Client, namespace string) error {
+func (t *IndirectTransfer) Cleanup(ctx context.Context, c client.Client, namespace, pvcName string) error {
 	if len(t.options.Labels) == 0 {
 		return fmt.Errorf("refusing to cleanup with empty labels: would match all pods in namespace %s", namespace)
 	}
+	cleanupLabels := copyLabels(t.options.Labels)
+	cleanupLabels["app.konveyor.io/created-for-pvc"] = pvcName
 	podList := &corev1.PodList{}
 	if err := c.List(ctx, podList,
 		client.InNamespace(namespace),
-		client.MatchingLabels(t.options.Labels)); err != nil {
+		client.MatchingLabels(cleanupLabels)); err != nil {
 		return fmt.Errorf("failed to list indirect transfer pods: %w", err)
 	}
 	for i := range podList.Items {

--- a/state_transfer/transfer/indirect/download.go
+++ b/state_transfer/transfer/indirect/download.go
@@ -7,11 +7,11 @@ import (
 	corev1 "k8s.io/api/core/v1"
 )
 
-func (t *IndirectTransfer) Download(ctx context.Context, pvc *corev1.PersistentVolumeClaim, remotePVCName string) (*corev1.Pod, error) {
+func (t *IndirectTransfer) Download(ctx context.Context, pvc *corev1.PersistentVolumeClaim, sourceNamespace, remotePVCName string) (*corev1.Pod, error) {
 	if err := t.options.Validate(); err != nil {
 		return nil, fmt.Errorf("invalid options for download: %w", err)
 	}
-	remotePath := fmt.Sprintf("%s/%s/%s", t.options.CloudStorage, pvc.Namespace, remotePVCName)
+	remotePath := fmt.Sprintf("%s/%s/%s", t.options.CloudStorage, sourceNamespace, remotePVCName)
 	command := buildRcloneCommand("sync", remotePath, dataMountPath)
 
 	pod := t.buildPod(
@@ -19,6 +19,7 @@ func (t *IndirectTransfer) Download(ctx context.Context, pvc *corev1.PersistentV
 		pvc.Namespace,
 		pvc.Name,
 		command,
+		t.options.DownloadSecurityContext,
 	)
 
 	if err := t.destClient.Create(ctx, pod); err != nil {

--- a/state_transfer/transfer/indirect/download.go
+++ b/state_transfer/transfer/indirect/download.go
@@ -8,6 +8,9 @@ import (
 )
 
 func (t *IndirectTransfer) Download(ctx context.Context, pvc *corev1.PersistentVolumeClaim, remotePVCName string) (*corev1.Pod, error) {
+	if err := t.options.Validate(); err != nil {
+		return nil, fmt.Errorf("invalid options for download: %w", err)
+	}
 	remotePath := fmt.Sprintf("%s/%s/%s", t.options.CloudStorage, pvc.Namespace, remotePVCName)
 	command := buildRcloneCommand("sync", remotePath, dataMountPath)
 

--- a/state_transfer/transfer/indirect/download.go
+++ b/state_transfer/transfer/indirect/download.go
@@ -1,0 +1,29 @@
+package indirect
+
+import (
+	"context"
+	"fmt"
+
+	corev1 "k8s.io/api/core/v1"
+)
+
+func (t *IndirectTransfer) Download(ctx context.Context, pvc *corev1.PersistentVolumeClaim, remotePVCName string) (*corev1.Pod, error) {
+	remotePath := fmt.Sprintf("%s/%s/%s", t.options.CloudStorage, pvc.Namespace, remotePVCName)
+	command := buildRcloneCommand("sync", remotePath, dataMountPath)
+
+	pod := t.buildPod(
+		fmt.Sprintf("rclone-download-%s", pvc.Name),
+		pvc.Namespace,
+		pvc.Name,
+		command,
+	)
+
+	if err := t.destClient.Create(ctx, pod); err != nil {
+		return nil, fmt.Errorf("failed to create download pod: %w", err)
+	}
+	return pod, nil
+}
+
+func (t *IndirectTransfer) IsDownloadComplete(ctx context.Context, podName, namespace string) (bool, error) {
+	return isPodComplete(ctx, t.destClient, podName, namespace)
+}

--- a/state_transfer/transfer/indirect/indirect.go
+++ b/state_transfer/transfer/indirect/indirect.go
@@ -20,13 +20,14 @@ const (
 )
 
 type Options struct {
-	Image           string
-	CloudStorage    string
-	ConfigSecret    string
-	Encrypt         bool
-	KeepCloudData   bool
-	Labels          map[string]string
-	SecurityContext corev1.PodSecurityContext
+	Image                  string
+	CloudStorage           string
+	ConfigSecret           string
+	Encrypt                bool
+	KeepCloudData          bool
+	Labels                 map[string]string
+	UploadSecurityContext  corev1.PodSecurityContext
+	DownloadSecurityContext corev1.PodSecurityContext
 }
 
 func (o *Options) Validate() error {
@@ -93,7 +94,7 @@ func truncatePodName(name string) string {
 	return strings.TrimRight(name, "-.")
 }
 
-func (t *IndirectTransfer) buildPod(name, namespace, pvcName string, command []string) *corev1.Pod {
+func (t *IndirectTransfer) buildPod(name, namespace, pvcName string, command []string, secCtx corev1.PodSecurityContext) *corev1.Pod {
 	return &corev1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      truncatePodName(name),
@@ -102,7 +103,7 @@ func (t *IndirectTransfer) buildPod(name, namespace, pvcName string, command []s
 		},
 		Spec: corev1.PodSpec{
 			RestartPolicy:   corev1.RestartPolicyNever,
-			SecurityContext: &t.options.SecurityContext,
+			SecurityContext: &secCtx,
 			Containers: []corev1.Container{
 				{
 					Name:    "rclone",
@@ -142,7 +143,6 @@ func buildRcloneCommand(subcommand, src, dst string) []string {
 		src, dst,
 		"--config", configMountPath + "/rclone.conf",
 		"--progress",
-		"--metadata",
 		"--links",
 		"-v",
 	}

--- a/state_transfer/transfer/indirect/indirect.go
+++ b/state_transfer/transfer/indirect/indirect.go
@@ -3,6 +3,7 @@ package indirect
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -48,7 +49,7 @@ func New(srcClient, destClient client.Client, opts Options) *IndirectTransfer {
 	if opts.Image == "" {
 		opts.Image = defaultImage
 	}
-	if opts.Labels == nil {
+	if len(opts.Labels) == 0 {
 		opts.Labels = map[string]string{
 			"app.kubernetes.io/name":      "crane",
 			"app.kubernetes.io/component": "indirect-transfer",
@@ -88,7 +89,8 @@ func truncatePodName(name string) string {
 	if len(name) <= maxPodNameLen {
 		return name
 	}
-	return name[:maxPodNameLen]
+	name = name[:maxPodNameLen]
+	return strings.TrimRight(name, "-.")
 }
 
 func (t *IndirectTransfer) buildPod(name, namespace, pvcName string, command []string) *corev1.Pod {

--- a/state_transfer/transfer/indirect/indirect.go
+++ b/state_transfer/transfer/indirect/indirect.go
@@ -95,11 +95,13 @@ func truncatePodName(name string) string {
 }
 
 func (t *IndirectTransfer) buildPod(name, namespace, pvcName string, command []string, secCtx corev1.PodSecurityContext) *corev1.Pod {
+	podLabels := copyLabels(t.options.Labels)
+	podLabels["app.konveyor.io/created-for-pvc"] = pvcName
 	return &corev1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      truncatePodName(name),
 			Namespace: namespace,
-			Labels:    copyLabels(t.options.Labels),
+			Labels:    podLabels,
 		},
 		Spec: corev1.PodSpec{
 			RestartPolicy:   corev1.RestartPolicyNever,

--- a/state_transfer/transfer/indirect/indirect.go
+++ b/state_transfer/transfer/indirect/indirect.go
@@ -23,7 +23,13 @@ type Options struct {
 	Image                  string
 	CloudStorage           string
 	ConfigSecret           string
+	// TODO: Encrypt enables client-side encryption via rclone crypt overlay.
+	// When set, crane should append a [encrypted] crypt remote section to rclone.conf
+	// and use "encrypted:" as the remote path instead of the direct S3 path.
 	Encrypt                bool
+	// TODO: KeepCloudData skips cloud storage cleanup after transfer.
+	// When false, a cleanup pod should run "rclone delete remote:bucket/ns/pvc/"
+	// after successful download to remove intermediate data from S3.
 	KeepCloudData          bool
 	Labels                 map[string]string
 	UploadSecurityContext  corev1.PodSecurityContext

--- a/state_transfer/transfer/indirect/indirect.go
+++ b/state_transfer/transfer/indirect/indirect.go
@@ -1,0 +1,147 @@
+package indirect
+
+import (
+	"context"
+	"fmt"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+const (
+	defaultImage     = "quay.io/konveyor/rsync-transfer:latest"
+	configMountPath  = "/etc/rclone"
+	dataMountPath    = "/data"
+	configVolumeName = "rclone-config"
+	dataVolumeName   = "data"
+	maxPodNameLen    = 63
+)
+
+type Options struct {
+	Image           string
+	CloudStorage    string
+	ConfigSecret    string
+	Encrypt         bool
+	KeepCloudData   bool
+	Labels          map[string]string
+	SecurityContext corev1.PodSecurityContext
+}
+
+func (o *Options) Validate() error {
+	if o.CloudStorage == "" {
+		return fmt.Errorf("cloud storage path is required")
+	}
+	if o.ConfigSecret == "" {
+		return fmt.Errorf("rclone config secret name is required")
+	}
+	return nil
+}
+
+type IndirectTransfer struct {
+	sourceClient client.Client
+	destClient   client.Client
+	options      Options
+}
+
+func New(srcClient, destClient client.Client, opts Options) *IndirectTransfer {
+	if opts.Image == "" {
+		opts.Image = defaultImage
+	}
+	if opts.Labels == nil {
+		opts.Labels = map[string]string{
+			"app.kubernetes.io/name":      "crane",
+			"app.kubernetes.io/component": "indirect-transfer",
+		}
+	}
+	return &IndirectTransfer{
+		sourceClient: srcClient,
+		destClient:   destClient,
+		options:      opts,
+	}
+}
+
+func isPodComplete(ctx context.Context, c client.Client, podName, namespace string) (bool, error) {
+	pod := &corev1.Pod{}
+	if err := c.Get(ctx, client.ObjectKey{Name: podName, Namespace: namespace}, pod); err != nil {
+		return false, err
+	}
+	switch pod.Status.Phase {
+	case corev1.PodSucceeded:
+		return true, nil
+	case corev1.PodFailed:
+		return true, fmt.Errorf("pod %s/%s failed", namespace, podName)
+	default:
+		return false, nil
+	}
+}
+
+func copyLabels(src map[string]string) map[string]string {
+	dst := make(map[string]string, len(src))
+	for k, v := range src {
+		dst[k] = v
+	}
+	return dst
+}
+
+func truncatePodName(name string) string {
+	if len(name) <= maxPodNameLen {
+		return name
+	}
+	return name[:maxPodNameLen]
+}
+
+func (t *IndirectTransfer) buildPod(name, namespace, pvcName string, command []string) *corev1.Pod {
+	return &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      truncatePodName(name),
+			Namespace: namespace,
+			Labels:    copyLabels(t.options.Labels),
+		},
+		Spec: corev1.PodSpec{
+			RestartPolicy:   corev1.RestartPolicyNever,
+			SecurityContext: &t.options.SecurityContext,
+			Containers: []corev1.Container{
+				{
+					Name:    "rclone",
+					Image:   t.options.Image,
+					Command: command,
+					VolumeMounts: []corev1.VolumeMount{
+						{Name: dataVolumeName, MountPath: dataMountPath},
+						{Name: configVolumeName, MountPath: configMountPath, ReadOnly: true},
+					},
+				},
+			},
+			Volumes: []corev1.Volume{
+				{
+					Name: dataVolumeName,
+					VolumeSource: corev1.VolumeSource{
+						PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{
+							ClaimName: pvcName,
+						},
+					},
+				},
+				{
+					Name: configVolumeName,
+					VolumeSource: corev1.VolumeSource{
+						Secret: &corev1.SecretVolumeSource{
+							SecretName: t.options.ConfigSecret,
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func buildRcloneCommand(subcommand, src, dst string) []string {
+	return []string{
+		"rclone", subcommand,
+		src, dst,
+		"--config", configMountPath + "/rclone.conf",
+		"--progress",
+		"--metadata",
+		"--links",
+		"-v",
+	}
+}

--- a/state_transfer/transfer/indirect/indirect_test.go
+++ b/state_transfer/transfer/indirect/indirect_test.go
@@ -1,0 +1,169 @@
+package indirect
+
+import (
+	"testing"
+)
+
+func TestBuildRcloneCommand(t *testing.T) {
+	tests := []struct {
+		name       string
+		subcommand string
+		src        string
+		dst        string
+		wantLen    int
+		wantFirst  string
+	}{
+		{
+			name:       "sync upload",
+			subcommand: "sync",
+			src:        "/data",
+			dst:        "remote:bucket/ns/pvc",
+			wantLen:    10,
+			wantFirst:  "rclone",
+		},
+		{
+			name:       "sync download",
+			subcommand: "sync",
+			src:        "remote:bucket/ns/pvc",
+			dst:        "/data",
+			wantLen:    10,
+			wantFirst:  "rclone",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := buildRcloneCommand(tt.subcommand, tt.src, tt.dst)
+			if len(got) != tt.wantLen {
+				t.Errorf("length = %d, want %d, got %v", len(got), tt.wantLen, got)
+			}
+			if got[0] != tt.wantFirst {
+				t.Errorf("first arg = %q, want %q", got[0], tt.wantFirst)
+			}
+			if got[1] != tt.subcommand {
+				t.Errorf("subcommand = %q, want %q", got[1], tt.subcommand)
+			}
+			if got[2] != tt.src {
+				t.Errorf("src = %q, want %q", got[2], tt.src)
+			}
+			if got[3] != tt.dst {
+				t.Errorf("dst = %q, want %q", got[3], tt.dst)
+			}
+		})
+	}
+}
+
+func TestBuildPod(t *testing.T) {
+	transfer := New(nil, nil, Options{
+		Image:        "test-image:latest",
+		ConfigSecret: "my-rclone-secret",
+		CloudStorage: "remote:my-bucket",
+		Labels: map[string]string{
+			"app": "test",
+		},
+	})
+
+	pvcName := "test-pvc"
+	command := []string{"rclone", "sync", "/data", "remote:bucket/ns/pvc"}
+	pod := transfer.buildPod("test-upload", "test-ns", pvcName, command)
+
+	if pod.Name != "test-upload" {
+		t.Errorf("pod name = %q, want %q", pod.Name, "test-upload")
+	}
+	if pod.Namespace != "test-ns" {
+		t.Errorf("pod namespace = %q, want %q", pod.Namespace, "test-ns")
+	}
+	if len(pod.Spec.Containers) != 1 {
+		t.Fatalf("containers = %d, want 1", len(pod.Spec.Containers))
+	}
+	if pod.Spec.Containers[0].Image != "test-image:latest" {
+		t.Errorf("image = %q, want %q", pod.Spec.Containers[0].Image, "test-image:latest")
+	}
+	if len(pod.Spec.Volumes) != 2 {
+		t.Fatalf("volumes = %d, want 2", len(pod.Spec.Volumes))
+	}
+	if pod.Spec.Volumes[0].PersistentVolumeClaim.ClaimName != pvcName {
+		t.Errorf("pvc claim = %q, want %q", pod.Spec.Volumes[0].PersistentVolumeClaim.ClaimName, pvcName)
+	}
+	if pod.Spec.Volumes[1].Secret.SecretName != "my-rclone-secret" {
+		t.Errorf("secret name = %q, want %q", pod.Spec.Volumes[1].Secret.SecretName, "my-rclone-secret")
+	}
+}
+
+func TestBuildPodLabelsAreCopied(t *testing.T) {
+	labels := map[string]string{"app": "test"}
+	transfer := New(nil, nil, Options{Labels: labels})
+
+	pod1 := transfer.buildPod("pod1", "ns", "pvc", []string{"echo"})
+	pod2 := transfer.buildPod("pod2", "ns", "pvc", []string{"echo"})
+
+	pod1.Labels["extra"] = "modified"
+	if _, found := pod2.Labels["extra"]; found {
+		t.Error("modifying pod1 labels should not affect pod2 labels")
+	}
+}
+
+func TestTruncatePodName(t *testing.T) {
+	short := "rclone-upload-mydata"
+	if got := truncatePodName(short); got != short {
+		t.Errorf("short name should not be truncated, got %q", got)
+	}
+
+	long := "rclone-upload-a-very-long-pvc-name-that-exceeds-sixty-three-characters-limit"
+	if got := truncatePodName(long); len(got) > maxPodNameLen {
+		t.Errorf("long name should be truncated to %d, got %d", maxPodNameLen, len(got))
+	}
+}
+
+func TestDefaultImage(t *testing.T) {
+	transfer := New(nil, nil, Options{})
+	if transfer.options.Image != defaultImage {
+		t.Errorf("default image = %q, want %q", transfer.options.Image, defaultImage)
+	}
+}
+
+func TestDefaultLabels(t *testing.T) {
+	transfer := New(nil, nil, Options{})
+	if transfer.options.Labels["app.kubernetes.io/name"] != "crane" {
+		t.Errorf("missing default label app.kubernetes.io/name")
+	}
+	if transfer.options.Labels["app.kubernetes.io/component"] != "indirect-transfer" {
+		t.Errorf("missing default label app.kubernetes.io/component")
+	}
+}
+
+func TestOptionsValidation(t *testing.T) {
+	tests := []struct {
+		name    string
+		opts    Options
+		wantErr bool
+	}{
+		{
+			name:    "valid options",
+			opts:    Options{CloudStorage: "remote:bucket", ConfigSecret: "my-secret"},
+			wantErr: false,
+		},
+		{
+			name:    "missing cloud storage",
+			opts:    Options{ConfigSecret: "my-secret"},
+			wantErr: true,
+		},
+		{
+			name:    "missing config secret",
+			opts:    Options{CloudStorage: "remote:bucket"},
+			wantErr: true,
+		},
+		{
+			name:    "both missing",
+			opts:    Options{},
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.opts.Validate()
+			if (err != nil) != tt.wantErr {
+				t.Errorf("Validate() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}

--- a/state_transfer/transfer/indirect/indirect_test.go
+++ b/state_transfer/transfer/indirect/indirect_test.go
@@ -109,8 +109,19 @@ func TestTruncatePodName(t *testing.T) {
 	}
 
 	long := "rclone-upload-a-very-long-pvc-name-that-exceeds-sixty-three-characters-limit"
-	if got := truncatePodName(long); len(got) > maxPodNameLen {
+	got := truncatePodName(long)
+	if len(got) > maxPodNameLen {
 		t.Errorf("long name should be truncated to %d, got %d", maxPodNameLen, len(got))
+	}
+
+	endsWithHyphen := "rclone-upload-a-very-long-pvc-name-that-exceeds-sixty-three-cha"
+	if len(endsWithHyphen) <= maxPodNameLen {
+		endsWithHyphen = endsWithHyphen + "racters-and-ends-with-hyphen-"
+	}
+	got = truncatePodName(endsWithHyphen)
+	lastChar := got[len(got)-1]
+	if lastChar == '-' || lastChar == '.' {
+		t.Errorf("truncated name should not end with hyphen or dot, got %q", got)
 	}
 }
 

--- a/state_transfer/transfer/indirect/indirect_test.go
+++ b/state_transfer/transfer/indirect/indirect_test.go
@@ -2,6 +2,8 @@ package indirect
 
 import (
 	"testing"
+
+	corev1 "k8s.io/api/core/v1"
 )
 
 func TestBuildRcloneCommand(t *testing.T) {
@@ -18,7 +20,7 @@ func TestBuildRcloneCommand(t *testing.T) {
 			subcommand: "sync",
 			src:        "/data",
 			dst:        "remote:bucket/ns/pvc",
-			wantLen:    10,
+			wantLen:    9,
 			wantFirst:  "rclone",
 		},
 		{
@@ -26,7 +28,7 @@ func TestBuildRcloneCommand(t *testing.T) {
 			subcommand: "sync",
 			src:        "remote:bucket/ns/pvc",
 			dst:        "/data",
-			wantLen:    10,
+			wantLen:    9,
 			wantFirst:  "rclone",
 		},
 	}
@@ -64,7 +66,7 @@ func TestBuildPod(t *testing.T) {
 
 	pvcName := "test-pvc"
 	command := []string{"rclone", "sync", "/data", "remote:bucket/ns/pvc"}
-	pod := transfer.buildPod("test-upload", "test-ns", pvcName, command)
+	pod := transfer.buildPod("test-upload", "test-ns", pvcName, command, corev1.PodSecurityContext{})
 
 	if pod.Name != "test-upload" {
 		t.Errorf("pod name = %q, want %q", pod.Name, "test-upload")
@@ -93,8 +95,8 @@ func TestBuildPodLabelsAreCopied(t *testing.T) {
 	labels := map[string]string{"app": "test"}
 	transfer := New(nil, nil, Options{Labels: labels})
 
-	pod1 := transfer.buildPod("pod1", "ns", "pvc", []string{"echo"})
-	pod2 := transfer.buildPod("pod2", "ns", "pvc", []string{"echo"})
+	pod1 := transfer.buildPod("pod1", "ns", "pvc", []string{"echo"}, corev1.PodSecurityContext{})
+	pod2 := transfer.buildPod("pod2", "ns", "pvc", []string{"echo"}, corev1.PodSecurityContext{})
 
 	pod1.Labels["extra"] = "modified"
 	if _, found := pod2.Labels["extra"]; found {

--- a/state_transfer/transfer/indirect/upload.go
+++ b/state_transfer/transfer/indirect/upload.go
@@ -19,6 +19,7 @@ func (t *IndirectTransfer) Upload(ctx context.Context, pvc *corev1.PersistentVol
 		pvc.Namespace,
 		pvc.Name,
 		command,
+		t.options.UploadSecurityContext,
 	)
 
 	if err := t.sourceClient.Create(ctx, pod); err != nil {

--- a/state_transfer/transfer/indirect/upload.go
+++ b/state_transfer/transfer/indirect/upload.go
@@ -8,6 +8,9 @@ import (
 )
 
 func (t *IndirectTransfer) Upload(ctx context.Context, pvc *corev1.PersistentVolumeClaim) (*corev1.Pod, error) {
+	if err := t.options.Validate(); err != nil {
+		return nil, fmt.Errorf("invalid options for upload: %w", err)
+	}
 	remotePath := fmt.Sprintf("%s/%s/%s", t.options.CloudStorage, pvc.Namespace, pvc.Name)
 	command := buildRcloneCommand("sync", dataMountPath, remotePath)
 

--- a/state_transfer/transfer/indirect/upload.go
+++ b/state_transfer/transfer/indirect/upload.go
@@ -1,0 +1,29 @@
+package indirect
+
+import (
+	"context"
+	"fmt"
+
+	corev1 "k8s.io/api/core/v1"
+)
+
+func (t *IndirectTransfer) Upload(ctx context.Context, pvc *corev1.PersistentVolumeClaim) (*corev1.Pod, error) {
+	remotePath := fmt.Sprintf("%s/%s/%s", t.options.CloudStorage, pvc.Namespace, pvc.Name)
+	command := buildRcloneCommand("sync", dataMountPath, remotePath)
+
+	pod := t.buildPod(
+		fmt.Sprintf("rclone-upload-%s", pvc.Name),
+		pvc.Namespace,
+		pvc.Name,
+		command,
+	)
+
+	if err := t.sourceClient.Create(ctx, pod); err != nil {
+		return nil, fmt.Errorf("failed to create upload pod: %w", err)
+	}
+	return pod, nil
+}
+
+func (t *IndirectTransfer) IsUploadComplete(ctx context.Context, podName, namespace string) (bool, error) {
+	return isPodComplete(ctx, t.sourceClient, podName, namespace)
+}


### PR DESCRIPTION
 ## Summary

  Add indirect transfer engine for PVC data migration via S3-compatible cloud storage. This enables `transfer-pvc` to migrate data between clusters without direct network connectivity,  each cluster only needs outbound access to the object store.

  ## New package: `state_transfer/transfer/indirect/`

  | File | Purpose |
  |------|---------|
  | `indirect.go` | Types, constructor, options validation, pod spec builder, rclone command builder |
  | `upload.go` | `Upload()` creates rclone upload pod on source, `IsUploadComplete()` checks pod status |
  | `download.go` | `Download()` creates rclone download pod on target, `IsDownloadComplete()` checks pod status |
  | `cleanup.go` | `Cleanup()` deletes pods by label, tolerates already-deleted pods |
  | `indirect_test.go` | 7 unit tests |

  ## Design points

  - **Does not implement the `Transfer` interface** — the existing interface assumes server-client pairs with transport and endpoint, which don't apply here
  - **Follows the file structure convention** of existing engines (separate files for upload, download, cleanup)
  - **Reuses the `rsync-transfer` container image** — rclone is compiled into it (separate PR on migtools/rsync-transfer)
  - **Pod spec** mounts PVC at `/data` and rclone config Secret at `/etc/rclone`
  - **rclone flags**: `--progress`,  `--links` (symlink handling), `-v`
  - **Encryption** is handled via rclone config (crypt remote overlay in `rclone.conf`), not CLI flags — crane generates the config when `--encrypt` is set
  - **Labels are copied** per pod to prevent shared map mutation
  - **Pod names truncated** to 63 chars for K8s naming compliance
  - **Cleanup tolerates NotFound** — already-deleted pods don't cause failures
  - **Options validation** requires `CloudStorage` and `ConfigSecret`

  ## Tests

  | Test | Verifies |
  |------|----------|
  | `TestBuildRcloneCommand` (2 cases) | Command construction for upload and download |
  | `TestBuildPod` | Pod spec: image, volumes, mounts, PVC claim, secret name |
  | `TestBuildPodLabelsAreCopied` | Modifying one pod's labels doesn't affect another |
  | `TestTruncatePodName` | Short names unchanged, long names truncated to 63 |
  | `TestDefaultImage` | Defaults to `quay.io/konveyor/rsync-transfer:latest` |
  | `TestDefaultLabels` | Defaults to crane indirect-transfer labels |
  | `TestOptionsValidation` (4 cases) | Validates CloudStorage and ConfigSecret required |

  All existing crane-lib tests pass unchanged.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * Added indirect state transfers between persistent volumes and cloud storage.
  * Added upload and download operations with progress tracking and completion checks.
  * Added configurable credentials, encryption, retention, labels, and security settings.
  * Added automatic creation and cleanup of transfer workloads.
  * Added validation and sensible defaults for transfer configuration.
  * Added isolated workload labeling and compliant workload naming.
  * Added safe cleanup that targets only matching workloads and handles already-removed workloads gracefully.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->